### PR TITLE
Epoch information for ValidatorResponse and ValidatorBalanceResponse

### DIFF
--- a/types/api.yaml
+++ b/types/api.yaml
@@ -15,6 +15,10 @@ ValidatorResponse:
       $ref: "#/ValidatorStatus"
     validator:
       $ref: "./validator.yaml#/Validator"
+    epoch:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - description: "Data are referred to this epoch."
 
 ValidatorBalanceResponse:
   type: object
@@ -27,6 +31,10 @@ ValidatorBalanceResponse:
       allOf:
         - $ref: "./primitive.yaml#/Gwei"
         - description: "Current validator balance in gwei."
+    epoch:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - description: "Data are referred to this epoch."
 
 ValidatorStatus:
   description: |


### PR DESCRIPTION
- Added information about **epoch** when responding to Validator and ValidatorBalance query. This allow the client to easily understand what epoch is referred by response data and this is essential when the query URL contains a label ("head", "finalized", etc.) and not a defined state.