### PR TITLE
Addition of prepare_beacon_proposer endpoint.

### DIFF
--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -4,19 +4,16 @@ post:
   description: |
     Prepares the beacon node for potential proposers by supplying information
     required when proposing blocks for the given validators.  The information
-    supplied for each validator index is considered persistent until overwritten
-    by new information for the given validator index, or until the beacon node
-    restarts.
+    supplied for each validator index will persist through the epoch in which
+    the call is submitted and for a further two epochs after that, or until the
+    beacon node restarts.  It is expected that validator clients will send this
+    information periodically, for example each epoch, to ensure beacon nodes have
+    correct and timely fee recipient information.
 
-    There is no guarantee that the beacon node will use the supplied fee recipient
-    when creating a block proposal, so on receipt of a proposed block the validator
-    should confirm that it finds the fee recipient within the block acceptable before
-    signing it.
-
-    Note that because the information is not persistent across beacon node restarts
-    it is recommended that either the beacon node is monitored for restarts or this
-    information is refreshed by resending this request periodically (for example,
-    each epoch).
+    Note that there is no guarantee that the beacon node will use the supplied fee
+    recipient when creating a block proposal, so on receipt of a proposed block the
+    validator should confirm that it finds the fee recipient within the block
+    acceptable before signing it.
 
     Also note that requests containing currently inactive or unknown validator
     indices will be accepted, as they may become active at a later epoch.

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -8,6 +8,11 @@ post:
     by new information for the given validator index, or until the beacon node
     restarts.
 
+    There is no guarantee that the beacon node will use the supplied fee recipient
+    when creating a block proposal, so on receipt of a proposed block the validator
+    should confirm that it finds the fee recipient within the block acceptable before
+    signing it.
+
     Note that because the information is not persistent across beacon node restarts
     it is recommended that either the beacon node is monitored for restarts or this
     information is refreshed by resending this request periodically (for example,

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -1,0 +1,40 @@
+post:
+  operationId: "prepareBeaconProposer"
+  summary: Provide beacon node with proposals for the given validators.
+  description: |
+    Prepares the beacon node for potential proposers by supplying information
+    required when proposing blocks for the given validators.  The information
+    supplied for each validator index is considered persistent until overwritten
+    by new information for the given validator index, or until the beacon node
+    restarts.
+
+    Note that bacause the information is not persistent across beacon node restarts
+    it is recommended that either the beacon node is monitored for restarts or this
+    information is refreshed by resending this request periodically (for example,
+    each epoch).
+
+    Also note that requests containing currently inactive or unknown validator
+    indices will be accepted, as they may become active at a later epoch.
+  tags:
+    - ValidatorRequiredApi
+    - Validator
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              validator_index:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+              fee_recipient:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress'
+  responses:
+    "200":
+      description: |
+        Preparation information has been received.
+    "400":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "500":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -8,7 +8,7 @@ post:
     by new information for the given validator index, or until the beacon node
     restarts.
 
-    Note that bacause the information is not persistent across beacon node restarts
+    Note that because the information is not persistent across beacon node restarts
     it is recommended that either the beacon node is monitored for restarts or this
     information is refreshed by resending this request periodically (for example,
     each epoch).

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -142,6 +142,8 @@ paths:
     $ref: "./apis/validator/sync_committee_contribution.yaml"
   /eth/v1/validator/contribution_and_proofs:
     $ref: "./apis/validator/sync_committee_contribution_and_proof.yaml"
+  /eth/v1/validator/prepare_beacon_proposer:
+    $ref: "./apis/validator/prepare_beacon_proposer.yaml"
 
   /eth/v1/events:
     $ref: "./apis/eventstream/index.yaml"
@@ -237,6 +239,8 @@ components:
       $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeContribution'
     Altair.SyncCommittee:
       $ref: './types/altair/sync_committee.yaml#/Altair/SyncCommitteeByValidatorIndices'
+    ExecutionAddress:
+      $ref: './types/primitive.yaml#/ExecutionAddress'
 
   parameters:
     StateId:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -58,3 +58,9 @@ Uint8:
   description: "Unsigned 8 bit integer, max value 255"
   pattern: "^[1-2]?[0-9]{1,2}$"
   example: "0"
+
+ExecutionAddress:
+  type: string
+  description: "An address on the execution (Ethereum 1) network."
+  example: "0xabcf8e0d4e9587369b2301d0790347320302cc09"
+  pattern: "^0x[a-fA-F0-9]{40}$"


### PR DESCRIPTION
This adds the `prepare_beacon_proposer` endpoint, required for the merge.  It follows on from discussion at https://github.com/sigp/lighthouse/issues/2715

There has been some debate over how to handle the fact that this information is not persistent over beacon node restarts.  The three options suggested are:
  - implict expiry _e.g._ the information expires 2 epochs after being provided or when the beacon node restarts, whichever is earlier
  - explicit expiry _e.g._ each request object has an `until_epoch` field such that the information expires at the given epoch or when the beacon node restarts, whichever is earlier
  - no expiry _i.e._  the information expires when the beacon node restarts

Given that the first two options still lose the data when the beacon node restarts the initial implementation uses the 'no expiry' option, however this could be changed if there is a compelling reason to do so.

There is a fourth option, which is to persist the information presented in the beacon node such that it survives beacon node restarts, however this was generally considered to be adding unnecessary complexity to beacon nodes.