### PR TITLE
Add not found responses for aggregates and contributions

### DIFF
--- a/apis/validator/aggregate_attestation.yaml
+++ b/apis/validator/aggregate_attestation.yaml
@@ -9,7 +9,7 @@ get:
     - name: attestation_data_root
       in: query
       required: true
-      description: "HashTreeRoot of AttestationData that validator want's aggregated"
+      description: "HashTreeRoot of AttestationData that validator wants aggregated"
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Root'
     - name: slot
@@ -29,15 +29,8 @@ get:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Attestation'
     "400":
-      description: "Invalid request"
-      content:
-        application/json:
-          schema:
-            $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-          examples:
-            NotAggregator:
-              value:
-                code: 403
-                message: Beacon node was not assigned to aggregate on that subnet.
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "404":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/NotFound'
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/sync_committee_contribution.yaml
+++ b/apis/validator/sync_committee_contribution.yaml
@@ -37,6 +37,8 @@ get:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommitteeContribution'
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "404":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/NotFound'
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -255,6 +255,8 @@ components:
   responses:
     InvalidRequest:
       $ref: './types/http.yaml#/InvalidRequest'
+    NotFound:
+      $ref: './types/http.yaml#/NotFound'
     InternalError:
       $ref: './types/http.yaml#/InternalError'
     CurrentlySyncing:


### PR DESCRIPTION
There are times when an aggregate or contribution is requested by a VC, and the beacon node simply doesn't have any information to return.

Returning 400 'bad request' is probably excessive in this case, the request may be perfectly valid and it's just that the BN wasn't able to respond with data.

We believe that a 404 in these cases would be warranted and allow us a better idea of actual bad requests vs. no data being found at the BN.