### PR TITLE
Clarify validator id as any bytes48

### DIFF
--- a/apis/beacon/states/validator.yaml
+++ b/apis/beacon/states/validator.yaml
@@ -10,7 +10,7 @@ get:
       in: path
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: validator_id
-      description: "Either hex encoded public key (with 0x prefix) or validator index"
+      description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
       in: path
       required: true
       schema:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -15,7 +15,7 @@ get:
       in: path
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: id
-      description: "Either hex encoded public key (with 0x prefix) or validator index"
+      description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
       in: query
       required: false
       schema:
@@ -23,7 +23,7 @@ get:
         maxItems: 30
         uniqueItems: true
         items:
-          description: "Either hex encoded public key (with 0x prefix) or validator index"
+          description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
           type: string
 
   responses:

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -15,7 +15,7 @@ get:
       in: path
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: id
-      description: "Either hex encoded public key (with 0x prefix) or validator index"
+      description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
       in: query
       required: false
       schema:
@@ -23,7 +23,7 @@ get:
         maxItems: 30
         uniqueItems: true
         items:
-          description: "Either hex encoded public key (with 0x prefix) or validator index"
+          description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
           type: string
     - name: status
       description: "[Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)"


### PR DESCRIPTION
Validator ID in a query parameter should not be required to be on the g2 curve to be valid, any bytes48 should be allowed to be queried on.

Reading in any bytes48 without validating against the g2 curve will reduce overheads of parsing large lists, and given that valid missing keys are just not returned, there are no real negatives to querying a key that will definitely be missing.

fixes #183