### PR TITLE
Added optional fee_recipient parameter to /eth/v2/validator/blocks/{s…

### DIFF
--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -28,6 +28,12 @@ get:
       description: "Arbitrary data validator wants to include in block."
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Graffiti'
+    - name: fee_recipient
+      in: query
+      required: false
+      description: "Address that will receive transaction fees collected in the block."
+      schema:
+        $ref: '../../beacon-node-oapi.yaml#/components/schemas/FeeRecipient'
   responses:
     "200":
       description: Success response

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -58,3 +58,8 @@ Uint8:
   description: "Unsigned 8 bit integer, max value 255"
   pattern: "^[1-2]?[0-9]{1,2}$"
   example: "0"
+
+FeeRecipient:
+  type: string
+  example: "0x00000000219ab540356cbb839cbe05303d7705fa"
+  pattern: "^0x[a-fA-F0-9]{40}$"


### PR DESCRIPTION
It would be nice to be able to set the fee recipient on a per-validator basis so that validators sharing a BN don't need to use the same address.
Currently this is not possible as there is no way to tell the BN to use a custom fee-recipient address.

This PR adds an optional fee_recipient parameter to `/eth/v2/validator/blocks/{slot}` which allows VC to specify a address that should be used to receive transaction fees collected in the block.