### PR TITLE
Replace deprecated docker actions and use npm packages directly

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: npm i -g @apidevtools/swagger-cli@4
       - name: Prepare deploy directory
         run: |
           mkdir ./deploy
@@ -17,9 +19,7 @@ jobs:
           cp -r assets ./deploy
           cp -r index.html ./deploy
       - name: Bundle spec
-        uses: mpetrunic/swagger-cli-action@v1.0.0
-        with:
-          command: "bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
+        run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
       - name: Publish to Github Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+    - run: npm i -g @apidevtools/swagger-cli@4 @stoplight/spectral-cli@6
 
     - name: Lint spec
-      uses: vaibhav-jain/spectral-action/@v2.6.1
-      with:
-        file_path: beacon-node-oapi.yaml
+      run: spectral lint ./beacon-node-oapi.yaml
 
     - name: Bundle spec
-      uses: mpetrunic/swagger-cli-action@v1.0.0
-      with:
-        command: "bundle ./beacon-node-oapi.yaml -r -t yaml -o ./bundle.yaml"
+      run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
-    - run: npm i -g @apidevtools/swagger-cli@4 @stoplight/spectral-cli@6
+    - run: npm i -g @apidevtools/swagger-cli@4 @stoplight/spectral-cli@6.2.0
+    - run: spectral --version
 
     - name: Lint spec
       run: spectral lint ./beacon-node-oapi.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,14 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: npm i -g @apidevtools/swagger-cli@4
       - name: Bundle yaml spec
-        uses: mpetrunic/swagger-cli-action@v1.0.0
-        with:
-          command: "bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
+        run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
       - name: Bundle json spec
-        uses: mpetrunic/swagger-cli-action@v1.0.0
-        with:
-          command: "bundle ./beacon-node-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
+        run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,7 +1,6 @@
 extends: [["spectral:oas", "all"]]
 formats: ["oas3"]
 rules:
-  operation-default-response: off
   operation-singular-tag: off
   oas3-parameter-description: off
   contact-properties: off

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,6 +1,7 @@
 extends: [["spectral:oas", "all"]]
 formats: ["oas3"]
 rules:
+  operation-default-response: off
   operation-singular-tag: off
   oas3-parameter-description: off
   contact-properties: off

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Api spec is checked for lint errors before merge.
 
 To run lint locally, install linter with
 ```
-npm install -g @stoplight/spectral
+npm install -g @stoplight/spectral-cli@6.2.1
 
 # OR
 
-yarn global add @stoplight/spectral
+yarn global add @stoplight/spectral-cli@6.2.1
 ```
 and run lint with
 ```

--- a/params/index.yaml
+++ b/params/index.yaml
@@ -1,7 +1,7 @@
 StateId:
+  required: true
   name: state_id
   in: path
-  required: true
   example: "head"
   schema:
     type: string
@@ -9,9 +9,9 @@ StateId:
     State identifier.
     Can be one of: "head" (canonical head in node's view), "genesis", "finalized", "justified", \<slot\>, \<hex encoded stateRoot with 0x prefix\>.
 BlockId:
+  required: true
   name: block_id
   in: path
-  required: true
   example: "head"
   schema:
     type: string


### PR DESCRIPTION
There was an increasing number of flaky ci, this should hopefully fix it as we are running the latest version of npm packages instead of deprecated ones in docker actions.