### PR TITLE
`getDebugChainHeadsV2`: move `execution_optimistic` into metadata

### DIFF
--- a/apis/debug/heads.v2.yaml
+++ b/apis/debug/heads.v2.yaml
@@ -13,6 +13,8 @@ get:
             title: GetDebugChainHeadsResponse
             type: object
             properties:
+              execution_optimistic:
+                      $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
               data:
                 type: array
                 items:
@@ -22,7 +24,5 @@ get:
                       $ref: "../../beacon-node-oapi.yaml#/components/schemas/Root"
                     slot:
                       $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
-                    execution_optimistic:
-                      $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
     "500":
       $ref: "../../beacon-node-oapi.yaml#/components/responses/InternalError"


### PR DESCRIPTION
The spec of `getDebugChainHeadsV2` has `execution_optimistic` as part of the `data` return value. It should be outside because it's metadata.