### PR TITLE
New endpoint for weak subjectivity data

### DIFF
--- a/apis/beacon/weak_subjectivity.yaml
+++ b/apis/beacon/weak_subjectivity.yaml
@@ -1,0 +1,34 @@
+  get:
+    operationId: getWeakSubjectivity
+    tags:
+      - Beacon
+    summary: "Retrieve weak subjectivity data based on the current chain head."
+    description: "Retrieve weak subjectivity data to be used for checkpoint validation or initiating checkpoint sync."
+    responses:
+      "200":
+        description: Request successful
+        content:
+          application/json:
+            schema:
+              type: object
+              title: GetWeakSubjectivityResponse
+              properties:
+                data:
+                  type: object
+                  properties:
+                    ws_checkpoint:
+                      $ref: "../../types/misc.yaml#/Checkpoint"
+                    state_root:
+                      $ref: '../../types/primitive.yaml#/Root'
+      "503":
+        description: "Weak Subjectivity data cannot be computed at this time (Beacon Node out of sync)."
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+                - example:
+                    code: 503 
+                    message: "Weak Subjectivity data cannot be computed at this time (Beacon Node out of sync)."
+      "500":
+        $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -89,6 +89,9 @@ paths:
   /eth/v1/beacon/pool/voluntary_exits:
     $ref: "./apis/beacon/pool/voluntary_exists.yaml"
 
+  /eth/v1/beacon/weak_subjectivity:
+    $ref: "./apis/beacon/weak_subjectivity.yaml"
+
   /eth/v1/debug/beacon/states/{state_id}:
     $ref: './apis/debug/state.yaml'
   /eth/v2/debug/beacon/states/{state_id}:


### PR DESCRIPTION
Resolves https://github.com/ethereum/beacon-APIs/issues/198

This adds an endpoint for retrieving weak subjectivity data. Please read #198 for rationale and uses. Thank you!