### PR TITLE
add is_optimistic to getSyncingStatus response

### DIFF
--- a/apis/node/syncing.yaml
+++ b/apis/node/syncing.yaml
@@ -4,7 +4,7 @@
       - Node
       - ValidatorRequiredApi
     summary: "Get node syncing status"
-    description: "Requests the beacon node to describe if it's currently syncing or not, and if it is, what block it is up to."
+    description: "ZZZ Requests the beacon node to describe if it's currently syncing or not, and if it is, what block it is up to."
     responses:
       "200":
         description: Request successful
@@ -26,7 +26,13 @@
                         - description: "How many slots node needs to process to reach head. 0 if synced."
                         - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     is_syncing:
-                      type: boolean
-                      description: "Set to true if the node is syncing, false if the node is synced."
+                      allOf:
+                        - type: boolean
+                        - description: "Set to true if the node is syncing, false if the node is synced."
+                    is_optimistic:
+                      allOf:
+                        - type: boolean
+                        - description: "Set to true if the node is optimistically tracking head (possible syncing reason)."
+
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/node/syncing.yaml
+++ b/apis/node/syncing.yaml
@@ -4,7 +4,7 @@
       - Node
       - ValidatorRequiredApi
     summary: "Get node syncing status"
-    description: "ZZZ Requests the beacon node to describe if it's currently syncing or not, and if it is, what block it is up to."
+    description: "Requests the beacon node to describe if it's currently syncing or not, and if it is, what block it is up to."
     responses:
       "200":
         description: Request successful
@@ -32,7 +32,7 @@
                     is_optimistic:
                       allOf:
                         - type: boolean
-                        - description: "Set to true if the node is optimistically tracking head (possible syncing reason)."
+                        - description: "Set to true if the node is optimistically tracking head."
 
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'


### PR DESCRIPTION
In Bellatrix, nodes that are optimistically tracking head will be responding with is_syncing as true, but be optimistically tracking head.

Added a new field to be able to determine that a node is optimistically tracking the head of the chain.
