### PR TITLE
Add ssz format for block production.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
-    - run: npm i -g @apidevtools/swagger-cli@4 @stoplight/spectral-cli@6.2.0
+    - run: npm i -g @apidevtools/swagger-cli@4 @stoplight/spectral-cli@6.3.0
     - run: spectral --version
 
     - name: Lint spec

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+deploy

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Api spec is checked for lint errors before merge.
 
 To run lint locally, install linter with
 ```
-npm install -g @stoplight/spectral-cli@6.2.1
+npm install -g @stoplight/spectral-cli@6.3.0
 
 # OR
 
-yarn global add @stoplight/spectral-cli@6.2.1
+yarn global add @stoplight/spectral-cli@6.3.0
 ```
 and run lint with
 ```

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -26,7 +26,7 @@ post:
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
       application/octet-stream:
         schema:
-          description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
+          description: "SSZ serialized block bytes. Use Accept header to choose this response type."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -3,6 +3,12 @@ post:
     - Beacon
     - ValidatorRequiredApi
   summary: "Publish a signed block."
+  parameters:
+    - name: "Eth-Consensus-Version"
+      in: header
+      allOf:
+        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+        - description: "Version of the block being submitted, if using SSZ encoding."
   operationId: "publishBlindedBlock"
   description: |
     Instructs the beacon node to use the components of the `SignedBlindedBeaconBlock` to construct and publish a 
@@ -26,7 +32,7 @@ post:
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
       application/octet-stream:
         schema:
-          description: "SSZ serialized block bytes. Use Accept header to indicate that SSZ data is contained in the request body."
+          description: "SSZ serialized block bytes. Use content type header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -26,7 +26,7 @@ post:
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
       application/octet-stream:
         schema:
-          description: "SSZ serialized block bytes. Use Accept header to choose this response type."
+          description: "SSZ serialized block bytes. Use Accept header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -3,12 +3,6 @@ post:
     - Beacon
     - ValidatorRequiredApi
   summary: "Publish a signed block."
-  parameters:
-    - name: "Eth-Consensus-Version"
-      in: header
-      allOf:
-        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-        - description: "Version of the block being submitted, if using SSZ encoding."
   operationId: "publishBlindedBlock"
   description: |
     Instructs the beacon node to use the components of the `SignedBlindedBeaconBlock` to construct and publish a 
@@ -20,6 +14,12 @@ post:
     therefore validate the block internally, however blocks which fail the validation are still
     broadcast but a different status code is returned (202). Pre-Bellatrix, this endpoint will accept 
     a `SignedBeaconBlock`.
+  parameters:
+    - name: "Eth-Consensus-Version"
+      in: header
+      allOf:
+        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+        - description: "Version of the block being submitted, if using SSZ encoding."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -24,6 +24,9 @@ post:
             - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock'
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -15,11 +15,12 @@ post:
     broadcast but a different status code is returned (202). Pre-Bellatrix, this endpoint will accept 
     a `SignedBeaconBlock`.
   parameters:
-    - name: "Eth-Consensus-Version"
-      in: header
-      allOf:
-        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-        - description: "Version of the block being submitted, if using SSZ encoding."
+    - in: header
+      schema:
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
+      required: false
+      name: Eth-Consensus-Version
+      description: "Version of the block being submitted, if using SSZ encoding."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -16,7 +16,7 @@ get:
       description: "Successful response"
       headers:
         Eth-Consensus-Version:
-          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/eth-consensus-version'
       content:
         application/json:
           schema:

--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -16,7 +16,7 @@ get:
       description: "Successful response"
       headers:
         Eth-Consensus-Version:
-          $ref: '../../../beacon-node-oapi.yaml#/components/headers/eth-consensus-version'
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
       content:
         application/json:
           schema:

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -23,7 +23,7 @@ post:
            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
       application/octet-stream:
         schema:
-          description: "SSZ serialized block bytes. Use Accept header to choose this response type."
+          description: "SSZ serialized block bytes. Use Accept header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -23,7 +23,7 @@ post:
            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
       application/octet-stream:
         schema:
-          description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
+          description: "SSZ serialized block bytes. Use Accept header to choose this response type."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -21,6 +21,9 @@ post:
            - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock'
            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -3,6 +3,12 @@ post:
     - Beacon
     - ValidatorRequiredApi
   summary: "Publish a signed block."
+  parameters:
+    - name: "Eth-Consensus-Version"
+      in: header
+      allOf:
+        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+        - description: "Version of the block being submitted, if using SSZ encoding."
   operationId: "publishBlock"
   description: |
     Instructs the beacon node to broadcast a newly signed beacon block to the beacon network,
@@ -23,7 +29,7 @@ post:
            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
       application/octet-stream:
         schema:
-          description: "SSZ serialized block bytes. Use Accept header to indicate that SSZ data is contained in the request body."
+          description: "SSZ serialized block bytes. Use content type header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: "The block was validated successfully and has been broadcast. It has also been integrated into the beacon node's database."

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -3,12 +3,6 @@ post:
     - Beacon
     - ValidatorRequiredApi
   summary: "Publish a signed block."
-  parameters:
-    - name: "Eth-Consensus-Version"
-      in: header
-      allOf:
-        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-        - description: "Version of the block being submitted, if using SSZ encoding."
   operationId: "publishBlock"
   description: |
     Instructs the beacon node to broadcast a newly signed beacon block to the beacon network,
@@ -17,6 +11,12 @@ post:
     successful. The beacon node is expected to integrate the new block into its state, and
     therefore validate the block internally, however blocks which fail the validation are still
     broadcast but a different status code is returned (202)
+  parameters:
+    - name: "Eth-Consensus-Version"
+      in: header
+      allOf:
+        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+        - description: "Version of the block being submitted, if using SSZ encoding."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -12,11 +12,12 @@ post:
     therefore validate the block internally, however blocks which fail the validation are still
     broadcast but a different status code is returned (202)
   parameters:
-    - name: "Eth-Consensus-Version"
-      in: header
-      allOf:
-        - $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-        - description: "Version of the block being submitted, if using SSZ encoding."
+    - in: header
+      schema:
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
+      required: false
+      name: Eth-Consensus-Version
+      description: "Version of the block being submitted, if using SSZ encoding."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -49,6 +49,9 @@ get:
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'
                   - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconBlock"
                   - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BlindedBeaconBlock"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
     "400":
       description: "Invalid block production request"
       content:

--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -51,7 +51,7 @@ get:
                   - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BlindedBeaconBlock"
         application/octet-stream:
           schema:
-            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
+            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is sent in header `Eth-Consensus-Version`."
     "400":
       description: "Invalid block production request"
       content:

--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -51,7 +51,7 @@ get:
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BeaconBlock"
         application/octet-stream:
           schema:
-            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
+            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is sent in header `Eth-Consensus-Version`."
     "400":
       description: "Invalid block production request"
       content:

--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -31,6 +31,9 @@ get:
   responses:
     "200":
       description: Success response
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
       content:
         application/json:
           schema:
@@ -46,6 +49,9 @@ get:
                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconBlock"
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BeaconBlock"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is returned in header `Eth-Consensus-Version`."
     "400":
       description: "Invalid block production request"
       content:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -270,7 +270,9 @@ components:
       $ref: './types/bellatrix/block.yaml#/Bellatrix/BlindedBeaconBlock'
     Bellatrix.SignedBlindedBeaconBlock:
       $ref: './types/bellatrix/block.yaml#/Bellatrix/SignedBlindedBeaconBlock'
-
+    ConsensusVersion:
+      enum: [phase0, altair, bellatrix]
+      example: "phase0"
   parameters:
     StateId:
       $ref: './params/index.yaml#/StateId'
@@ -288,9 +290,8 @@ components:
       $ref: './types/http.yaml#/CurrentlySyncing'
 
   headers:
-    Eth-Consensus-Version:
+    eth-consensus-version:
       description: Required in response so client can deserialize returned json or ssz data more effectively.
+      required: true
       schema:
-        type: string
-        enum: [phase0, altair, bellatrix]
-        example: "phase0"
+        $ref: '#/components/schemas/ConsensusVersion'

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -290,7 +290,7 @@ components:
       $ref: './types/http.yaml#/CurrentlySyncing'
 
   headers:
-    eth-consensus-version:
+    Eth-Consensus-Version:
       description: Required in response so client can deserialize returned json or ssz data more effectively.
       required: true
       schema:


### PR DESCRIPTION
Block production and signed block consumption should allow SSZ encoding to help us reduce overheads on for api consumers.

Fallbacks will likely remain json for clients anyway if they're not reading the headers, but if they do read the headers then there's big performance gains to be had in returning / consuming SSZ.

At a later time it may be worth also accepting SSZ on other endpoints also.