### PR TITLE
Add validator registration

### DIFF
--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -12,7 +12,7 @@ post:
 
     Optionally the validator may also include a signed validator registration
     which will be used by the Builder API to verify a validator's latest fee
-    recipient and preferred target gas limit.
+    recipient and preferred gas limit.
 
     Note that there is no guarantee that the beacon node will use the supplied fee
     recipient when creating a block proposal, so on receipt of a proposed block the

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -12,7 +12,7 @@ post:
 
     Optionally the validator may also include a signed validator registration
     which will be used by the Builder API to verify a validator's latest fee
-    recipient.
+    recipient and preferred gas target.
 
     Note that there is no guarantee that the beacon node will use the supplied fee
     recipient when creating a block proposal, so on receipt of a proposed block the
@@ -40,6 +40,8 @@ post:
                 type: object
                 properties:
                   timestamp:
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                  gas_target:
                     $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
                   signature:
                     $ref: '../../beacon-node-oapi.yaml#/components/schemas/Signature'

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -10,6 +10,10 @@ post:
     information periodically, for example each epoch, to ensure beacon nodes have
     correct and timely fee recipient information.
 
+    Optionally the validator may also include a signed validator registration
+    which will be used by the Builder API to verify a validator's latest fee
+    recipient.
+
     Note that there is no guarantee that the beacon node will use the supplied fee
     recipient when creating a block proposal, so on receipt of a proposed block the
     validator should confirm that it finds the fee recipient within the block
@@ -32,6 +36,14 @@ post:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               fee_recipient:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress'
+              validator_registration:
+                type: object
+                properties:
+                  timestamp:
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                  signature:
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Signature'
+
   responses:
     "200":
       description: |

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -12,7 +12,7 @@ post:
 
     Optionally the validator may also include a signed validator registration
     which will be used by the Builder API to verify a validator's latest fee
-    recipient and preferred gas target.
+    recipient and preferred target gas limit.
 
     Note that there is no guarantee that the beacon node will use the supplied fee
     recipient when creating a block proposal, so on receipt of a proposed block the
@@ -41,7 +41,7 @@ post:
                 properties:
                   timestamp:
                     $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                  gas_target:
+                  gas_limit:
                     $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
                   signature:
                     $ref: '../../beacon-node-oapi.yaml#/components/schemas/Signature'


### PR DESCRIPTION
One requirement of the [Builder API](https://github.com/ethereum/execution-apis/pull/209) is in `builder_registerValidatorV1`, the validator must sign a message to authenticate its registration. This is to ensure only the person who controls the validator can set its `fee_recipient`, even in a multi-party environment. 

Registering currently entails signing over a `timestamp`, `pubkey`, and `fee_recipient`. The new, optional `validator_registration` object on `prepare_beacon_proposer` includes the minimal additional values (`timestamp` and `signature`) needed to satisfy the registration. If preferred, I could expand `validator_registration` to all required fields to verify the signature -- this would lead to duplication of `fee_recipient` and a new value `pubkey` which is already specified by `validator_index`.

This is my first PR to the beacon API so please let me know what I'm missing :pray: 