### PR TITLE
Fix broken link by making document into Jekyll page

### DIFF
--- a/validator-flow.md
+++ b/validator-flow.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: "Validator flow"
+permalink: /validator-flow/
+---
+
 # Validator Flow
 
 Detail explanation how validator should utilize this API to perform his regular BeaconChain duties.


### PR DESCRIPTION
The link for the validator-flow.md was broken on the rendered site because Jekyll (which currently renders the HTML) does not detect the markdown document as a valid page without "front matter".

This PR adds the required data.