### PR TITLE
Add `register_validator` endpoint

### DIFF
--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -23,8 +23,7 @@ post:
               $ref: '../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration'
   responses:
     "200":
-      description: |
-        Preparation information has been received.
+      description: Registration information has been received.
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "500":

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -3,12 +3,12 @@ post:
   summary: Provide beacon node with registrations for the given validators to the external builder network.
   description: |
     Prepares the beacon node for engaging with external builders. The
-    information will be sent by the beacon node to each external builder it is
-    connected to. It is expected that the validator client will send this
-    information periodically to ensure the beacon node has correct and timely
-    registration information to provide to builders. The validator client
-    should not sign blinded beacon blocks that do not adhere to their latest
-    fee recipient and gas limit preferences.
+    information will be sent by the beacon node to the builder network. It is
+    expected that the validator client will send this information periodically
+    to ensure the beacon node has correct and timely registration information
+    to provide to builders. The validator client should not sign blinded beacon
+    blocks that do not adhere to their latest fee recipient and gas limit
+    preferences.
 
     Note that requests containing currently inactive or unknown validator
     pubkeys will be accepted, as they may become active at a later epoch.

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -1,0 +1,31 @@
+post:
+  operationId: "registerValidator"
+  summary: Provide beacon node with registrations for the given validators to the external builder network.
+  description: |
+    Prepares the beacon node for engaging with external builders. The
+    information will be sent by the beacon node to each external builders it is
+    connected to. It is expected that the validator client will send this
+    information periodically to ensure the beacon node has correct and timely
+    registration information to provide to builders. The validator client
+    should not sign blinded beacon blocks that do not adhere to their latest
+    fee recipient and gas limit preferences.
+
+    Note that requests containing currently inactive or unknown validator
+    indices will be accepted, as they may become active at a later epoch.
+  tags:
+    - Validator
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+              $ref: '../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration'
+  responses:
+    "200":
+      description: |
+        Preparation information has been received.
+    "400":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "500":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -11,7 +11,7 @@ post:
     fee recipient and gas limit preferences.
 
     Note that requests containing currently inactive or unknown validator
-    indices will be accepted, as they may become active at a later epoch.
+    pubkeys will be accepted, as they may become active at a later epoch.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -3,7 +3,7 @@ post:
   summary: Provide beacon node with registrations for the given validators to the external builder network.
   description: |
     Prepares the beacon node for engaging with external builders. The
-    information will be sent by the beacon node to each external builders it is
+    information will be sent by the beacon node to each external builder it is
     connected to. It is expected that the validator client will send this
     information periodically to ensure the beacon node has correct and timely
     registration information to provide to builders. The validator client

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -161,6 +161,8 @@ paths:
     $ref: "./apis/validator/sync_committee_contribution_and_proof.yaml"
   /eth/v1/validator/prepare_beacon_proposer:
     $ref: "./apis/validator/prepare_beacon_proposer.yaml"
+  /eth/v1/validator/register_validator:
+    $ref: "./apis/validator/register_validator.yaml"
 
   /eth/v1/events:
     $ref: "./apis/eventstream/index.yaml"
@@ -273,6 +275,9 @@ components:
     ConsensusVersion:
       enum: [phase0, altair, bellatrix]
       example: "phase0"
+    SignedValidatorRegistration:
+      $ref: './types/registration.yaml#/SignedValidatorRegistration'
+
   parameters:
     StateId:
       $ref: './params/index.yaml#/StateId'

--- a/types/registration.yaml
+++ b/types/registration.yaml
@@ -1,0 +1,29 @@
+ValidatorRegistration:
+  type: object
+  description: "The [`ValidatorRegistration`]() object from the Builder API spec."
+  properties:
+    fee_recipient:
+      allOf:
+        - $ref: '../beacon-apis/types/primitive.yaml#/ExecutionAddress'
+        - description: "Address to receive fees from the block."
+    gas_limit:
+      allOf:
+        - $ref: "../beacon-apis/types/primitive.yaml#/Uint64"
+        - description: "Gas limit the validator desires to target."
+    timestamp:
+      allOf:
+        - $ref: '../beacon-apis/types/primitive.yaml#/Uint64'
+        - description: "Unix timestamp of registration."
+    pubkey:
+      allOf:
+        - $ref: '../beacon-apis/types/primitive.yaml#/Pubkey'
+        - description: "BLS public key of validator."
+
+SignedValidatorRegistration:
+  type: object
+  description: "The [`SignedValidatorRegistration`]() object from the Builder API spec."
+  properties:
+    message:
+      $ref: "#/ValidatorRegistration"
+    signature:
+      $ref: "../beacon-apis/types/primitive.yaml#/Signature"

--- a/types/registration.yaml
+++ b/types/registration.yaml
@@ -3,17 +3,17 @@ ValidatorRegistration:
   description: "The `ValidatorRegistration` object from the Builder API specification."
   properties:
     fee_recipient:
-        - $ref: 'primitive.yaml#/ExecutionAddress'
-        - description: "Address to receive fees from the block."
+      $ref: 'primitive.yaml#/ExecutionAddress'
+      description: "Address to receive fees from the block."
     gas_limit:
-        - $ref: "primitive.yaml#/Uint64"
-        - description: "Preferred gas limit of validator."
+      $ref: "primitive.yaml#/Uint64"
+      description: "Preferred gas limit of validator."
     timestamp:
-        - $ref: 'primitive.yaml#/Uint64'
-        - description: "Unix timestamp of registration."
+      $ref: 'primitive.yaml#/Uint64'
+      description: "Unix timestamp of registration."
     pubkey:
-        - $ref: 'primitive.yaml#/Pubkey'
-        - description: "BLS public key of validator."
+      $ref: 'primitive.yaml#/Pubkey'
+      description: "BLS public key of validator."
 
 SignedValidatorRegistration:
   type: object

--- a/types/registration.yaml
+++ b/types/registration.yaml
@@ -1,27 +1,23 @@
 ValidatorRegistration:
   type: object
-  description: "The [`ValidatorRegistration`]() object from the Builder API spec."
+  description: "The `ValidatorRegistration` object from the Builder API specification."
   properties:
     fee_recipient:
-      allOf:
         - $ref: 'primitive.yaml#/ExecutionAddress'
         - description: "Address to receive fees from the block."
     gas_limit:
-      allOf:
         - $ref: "primitive.yaml#/Uint64"
-        - description: "Gas limit the validator desires to target."
+        - description: "Preferred gas limit of validator."
     timestamp:
-      allOf:
         - $ref: 'primitive.yaml#/Uint64'
         - description: "Unix timestamp of registration."
     pubkey:
-      allOf:
         - $ref: 'primitive.yaml#/Pubkey'
         - description: "BLS public key of validator."
 
 SignedValidatorRegistration:
   type: object
-  description: "The [`SignedValidatorRegistration`]() object from the Builder API spec."
+  description: "The `SignedValidatorRegistration` object from the Builder API specification."
   properties:
     message:
       $ref: "#/ValidatorRegistration"

--- a/types/registration.yaml
+++ b/types/registration.yaml
@@ -4,19 +4,19 @@ ValidatorRegistration:
   properties:
     fee_recipient:
       allOf:
-        - $ref: '../beacon-apis/types/primitive.yaml#/ExecutionAddress'
+        - $ref: 'primitive.yaml#/ExecutionAddress'
         - description: "Address to receive fees from the block."
     gas_limit:
       allOf:
-        - $ref: "../beacon-apis/types/primitive.yaml#/Uint64"
+        - $ref: "primitive.yaml#/Uint64"
         - description: "Gas limit the validator desires to target."
     timestamp:
       allOf:
-        - $ref: '../beacon-apis/types/primitive.yaml#/Uint64'
+        - $ref: 'primitive.yaml#/Uint64'
         - description: "Unix timestamp of registration."
     pubkey:
       allOf:
-        - $ref: '../beacon-apis/types/primitive.yaml#/Pubkey'
+        - $ref: 'primitive.yaml#/Pubkey'
         - description: "BLS public key of validator."
 
 SignedValidatorRegistration:
@@ -26,4 +26,4 @@ SignedValidatorRegistration:
     message:
       $ref: "#/ValidatorRegistration"
     signature:
-      $ref: "../beacon-apis/types/primitive.yaml#/Signature"
+      $ref: "primitive.yaml#/Signature"


### PR DESCRIPTION
This is another take on #206.

Rather than extending `prepare_beacon_proposer`, in this PR we create a new, separate endpoint `register_validator`. This addresses two pieces of feedback raised against the extension:

1) `prepare_beacon_proposer` performs a critical operation and probably shouldn't be encumbered by any additional responsibilities
2) `register_validator` will likely be executed on a different rhythm than `prepare_beacon_proposer`, so it feels more appropriate to separate out that logic

--

Now a short recap on why it's important this data is sent to the beacon node in the first place.

After the merge, validators will want to extract MEV from blocks. The mechanism that will facilitate this extraction a network of external builders. These builders will provide `ExecutionPayloadHeader`s to proposers to include in their beacon blocks with the promise that they will be paid a portion of the extracted value. From the perspective of the builder, most values in the header are deterministic depending on what the parent is. However, it is important that a few parameters remain under control of the proposer.

First is obviously the `fee_recipient`. Although it's not critical that the payload's actual `fee_recipient` be set to the proposer's preferred address (a simple transfer at the end of the block would suffice), it is crucial block builders have this information ahead of time so that they can begin constructing blocks immediately after their forkchoice moves forward.

The second parameter that is on the critical path to production is `gas_limit`. Strictly speaking, builders could decide whatever limit they like under the rules of consensus, however this gives a small number of builders a lot of power over this protocol parameter. Validators are more aligned with choosing a healthy gas limit, so it's best that value is left up to them.

In order to provide these two values to builders ahead of time in an form that can be authenticated, we introduce this new endpoint. By signing over these values and a timestamp, builders can determine validator's latest preferences before they are scheduled to propose.

The Builder API and spec is currently being developed in [`ethereum/builder-specs`](https://github.com/ethereum/builder-specs). A new domain type has also [been proposed ](https://github.com/ethereum/consensus-specs/pull/2884)which will be utilized by this endpoint to avoid a conflict with consensus-level messages.