### PR TITLE
Replace `eth2.0` with consensus layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ API browser: [https://ethereum.github.io/beacon-APIs/](https://ethereum.github.i
 ## Outline
 
 This document outlines an application programming interface (API) which is exposed by a beacon node implementation
- which aims to facilitate [Phase 0](https://github.com/ethereum/eth2.0-specs#phase-0) of the Etheruem consensus layer.
+ which aims to facilitate [Phase 0](https://github.com/ethereum/consensus-specs#phase-0) of the Etheruem consensus layer.
 
 The API is a REST interface, accessed via HTTP. The API should not, unless protected by additional security layers, be exposed to the public Internet as the API includes multiple endpoints which could open your node to denial-of-service (DoS) attacks through endpoints triggering heavy processing.
  Currently, the only supported return data type is JSON.
@@ -78,7 +78,7 @@ https://www.npmjs.com/package/@chainsafe/eth2.0-api-wrapper
 
    - Make sure info.version in beacon-node-oapi.yaml file is updated before tagging.
    - CD will create github release and upload bundled spec file
-   
+
 2. Add release entrypoint in index.html
 
 In SwaggerUIBundle configuration (inside index.html file), add another entry in "urls" field (SwaggerUI will load first item as default).

--- a/apis/beacon/states/fork.yaml
+++ b/apis/beacon/states/fork.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: "getStateFork"
   summary: "Get Fork object for requested state"
-  description: "Returns [Fork](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#fork) object for state with given 'stateId'."
+  description: "Returns [Fork](https://github.com/ethereum/consensus-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#fork) object for state with given 'stateId'."
   tags:
     - Beacon
     - ValidatorRequiredApi

--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -3,9 +3,9 @@ get:
   summary: Get spec params.
   description: |
     Retrieve specification configuration used on this node.  The configuration should include:
-      - Constants for all hard forks known by the beacon node, for example the [phase 0](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#constants) and [altair](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#constants) values
-      - Presets for all hard forks supplied to the beacon node, for example the [phase 0](https://github.com/ethereum/eth2.0-specs/blob/dev/presets/mainnet/phase0.yaml) and [altair](https://github.com/ethereum/eth2.0-specs/blob/dev/presets/mainnet/altair.yaml) values
-      - Configuration for the beacon node, for example the [mainnet](https://github.com/ethereum/eth2.0-specs/blob/dev/configs/mainnet.yaml) values
+      - Constants for all hard forks known by the beacon node, for example the [phase 0](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#constants) and [altair](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#constants) values
+      - Presets for all hard forks supplied to the beacon node, for example the [phase 0](https://github.com/ethereum/consensus-specs/blob/dev/presets/mainnet/phase0.yaml) and [altair](https://github.com/ethereum/consensus-specs/blob/dev/presets/mainnet/altair.yaml) values
+      - Configuration for the beacon node, for example the [mainnet](https://github.com/ethereum/consensus-specs/blob/dev/configs/mainnet.yaml) values
 
     Values are returned with following format:
       - any value starting with 0x in the spec is returned as a hex string

--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -22,7 +22,7 @@ Altair:
 
   BeaconBlockBody:
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblockbody) object from the Eth2.0 Altair spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblockbody) object from the CL Altair spec."
     properties:
       randao_reveal:
         allOf:
@@ -57,7 +57,7 @@ Altair:
         $ref: './sync_aggregate.yaml#/Altair/SyncAggregate'
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblock) object from the Eth2.0 Altair spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblock) object from the CL Altair spec."
     allOf:
       - $ref: '#/Altair/BeaconBlockCommon'
       - type: object
@@ -67,7 +67,7 @@ Altair:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#signedbeaconblock) object envelope from the Eth2.0 Altair spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#signedbeaconblock) object envelope from the CL Altair spec."
     properties:
       message:
         $ref: "#/Altair/BeaconBlock"

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -1,7 +1,7 @@
 Altair:
   BeaconState:
     type: object
-    description: "The [`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconstate) object from the Eth2.0 Altair spec."
+    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconstate) object from the CL Altair spec."
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/altair/sync_aggregate.yaml
+++ b/types/altair/sync_aggregate.yaml
@@ -1,7 +1,7 @@
 Altair:
   SyncAggregate:
     type: object
-    description: "The [`SyncAggregate`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#syncaggregate) object from the Eth2.0 Altair spec."
+    description: "The [`SyncAggregate`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#syncaggregate) object from the CL Altair spec."
     properties:
       sync_committee_bits:
         type: string

--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -1,6 +1,6 @@
 IndexedAttestation:
   type: object
-  description: "The [`IndexedAttestation`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#indexedattestation) object from the Eth2.0 spec."
+  description: "The [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#indexedattestation) object from the CL spec."
   properties:
     attesting_indices:
       type: array
@@ -17,7 +17,7 @@ IndexedAttestation:
 
 Attestation:
   type: object
-  description: "The [`Attestation`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestation) object from the Eth2.0 spec."
+  description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestation) object from the CL spec."
   properties:
     aggregation_bits:
       type: string
@@ -33,7 +33,7 @@ Attestation:
 
 PendingAttestation:
   type: object
-  description: "The [`PendingAttestation`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#pendingattestation) object from the Eth2.0 spec."
+  description: "The [`PendingAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#pendingattestation) object from the CL spec."
   properties:
     aggregation_bits:
       type: string
@@ -48,7 +48,7 @@ PendingAttestation:
 
 AttestationData:
   type: object
-  description: "The [`AttestationData`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestationdata) object from the Eth2.0 spec."
+  description: "The [`AttestationData`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestationdata) object from the CL spec."
   properties:
     slot:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/attester_slashing.yaml
+++ b/types/attester_slashing.yaml
@@ -1,6 +1,6 @@
 AttesterSlashing:
   type: object
-  description: "The [`AttesterSlashing`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/core/0_beacon-chain.md#attesterslashing) object from the Eth2.0 spec."
+  description: "The [`AttesterSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/core/0_beacon-chain.md#attesterslashing) object from the CL spec."
   properties:
     attestation_1:
       $ref: './attestation.yaml#/IndexedAttestation'

--- a/types/bellatrix/block.yaml
+++ b/types/bellatrix/block.yaml
@@ -2,7 +2,7 @@ Bellatrix:
   BeaconBlockBodyCommon:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the Eth2.0 Bellatrix spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec."
     properties:
       randao_reveal:
         allOf:
@@ -45,7 +45,7 @@ Bellatrix:
             $ref: './execution_payload.yaml#/Bellatrix/ExecutionPayload'
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblock) object from the Eth2.0 Bellatrix spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblock) object from the CL Bellatrix spec."
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
@@ -55,7 +55,7 @@ Bellatrix:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#signedbeaconblock) object envelope from the Eth2.0 Bellatrix spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec."
     properties:
       message:
         $ref: "#/Bellatrix/BeaconBlock"
@@ -63,7 +63,7 @@ Bellatrix:
         $ref: "../primitive.yaml#/Signature"
 
   BlindedBeaconBlockBody:
-    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the Eth2.0 Bellatrix spec, which contains a transactions root rather than a full transactions list."
+    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec, which contains a transactions root rather than a full transactions list."
     allOf:
       - $ref: '#/Bellatrix/BeaconBlockBodyCommon'
       - type: object
@@ -72,7 +72,7 @@ Bellatrix:
             $ref: './execution_payload.yaml#/Bellatrix/ExecutionPayloadHeader'
 
   BlindedBeaconBlock:
-    description: "A variant of the the [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblock) object from the Eth2.0 Bellatrix spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
+    description: "A variant of the the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblock) object from the CL Bellatrix spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
@@ -82,7 +82,7 @@ Bellatrix:
 
   SignedBlindedBeaconBlock:
     type: object
-    description: "A variant of the the the [`SignedBeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#signedbeaconblock) object envelope from the Eth2.0 Bellatrix spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    description: "A variant of the the the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
     properties:
       message:
         $ref: "#/Bellatrix/BlindedBeaconBlock"

--- a/types/bellatrix/execution_payload.yaml
+++ b/types/bellatrix/execution_payload.yaml
@@ -2,7 +2,7 @@ Bellatrix:
   ExecutionPayloadCommon:
     # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
     type: object
-    description: "The [`ExecutionPayload`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.9/specs/bellatrix) object from the Eth2.0 Bellatrix spec."
+    description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix) object from the CL Bellatrix spec."
     properties:
       parent_hash:
         $ref: '../primitive.yaml#/Root'

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -21,7 +21,7 @@ BeaconBlockCommon:
 
 BeaconBlockBody:
   type: object
-  description: "The [`BeaconBlockBody`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockbody) object from the Eth2.0 spec."
+  description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockbody) object from the CL spec."
   properties:
     randao_reveal:
       allOf:
@@ -55,7 +55,7 @@ BeaconBlockBody:
 
 
 BeaconBlock:
-  description: "The [`BeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock) object from the Eth2.0 spec."
+  description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
   allOf:
     - $ref: '#/BeaconBlockCommon'
     - type: object
@@ -65,7 +65,7 @@ BeaconBlock:
 
 SignedBeaconBlock:
   type: object
-  description: "The [`SignedBeaconBlock`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the Eth2.0 spec."
+  description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL spec."
   properties:
     message:
       $ref: "#/BeaconBlock"
@@ -73,7 +73,7 @@ SignedBeaconBlock:
       $ref: "./primitive.yaml#/Signature"
 
 BeaconBlockHeader:
-  description: "The [`BeaconBlockHeader`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockheader) object from the Eth2.0 spec."
+  description: "The [`BeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockheader) object from the CL spec."
   allOf:
     - $ref: './block.yaml#/BeaconBlockCommon'
     - type: object
@@ -85,7 +85,7 @@ BeaconBlockHeader:
 
 SignedBeaconBlockHeader:
   type: object
-  description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the Eth2.0 spec."
+  description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the CL spec."
   properties:
     message:
       $ref: "./block.yaml#/BeaconBlockHeader"

--- a/types/deposit.yaml
+++ b/types/deposit.yaml
@@ -1,6 +1,6 @@
 Deposit:
   type: object
-  description: "The [`Deposit`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#deposit) object from the Eth2.0 spec."
+  description: "The [`Deposit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#deposit) object from the CL spec."
   properties:
     proof:
       type: array
@@ -14,7 +14,7 @@ Deposit:
       $ref: './deposit.yaml#/DepositData'
 DepositData:
   type: object
-  description: "The [`DepositData`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#depositdata) object from the Eth2.0 spec."
+  description: "The [`DepositData`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#depositdata) object from the CL spec."
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'

--- a/types/eth1.yaml
+++ b/types/eth1.yaml
@@ -1,6 +1,6 @@
 Eth1Data:
   type: object
-  description: "The [`Eth1Data`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#eth1data) object from the Eth2.0 spec."
+  description: "The [`Eth1Data`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#eth1data) object from the CL spec."
   properties:
     deposit_root:
       allOf:

--- a/types/misc.yaml
+++ b/types/misc.yaml
@@ -1,6 +1,6 @@
 Fork:
   type: object
-  description: "The [`Fork`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#fork) object from the Eth2.0 spec."
+  description: "The [`Fork`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#fork) object from the CL spec."
   properties:
     previous_version:
       $ref: "./primitive.yaml#/ForkVersion"
@@ -11,7 +11,7 @@ Fork:
 
 Checkpoint:
   type: object
-  description: "The [`Checkpoint`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#checkpoint"
+  description: "The [`Checkpoint`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#checkpoint"
   properties:
     epoch:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -23,7 +23,7 @@ NetworkIdentity:
 
 MetaData:
   type: object
-  description: "Based on eth2 [Metadata object](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#metadata)"
+  description: "Based on eth2 [Metadata object](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#metadata)"
   properties:
     seq_number:
       allOf:

--- a/types/proposer_slashing.yaml
+++ b/types/proposer_slashing.yaml
@@ -1,6 +1,6 @@
 ProposerSlashing:
   type: object
-  description: "The [`ProposerSlashing`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#proposerslashing) object from the Eth2.0 spec."
+  description: "The [`ProposerSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#proposerslashing) object from the CL spec."
   properties:
     signed_header_1:
       $ref: './block.yaml#/SignedBeaconBlockHeader'

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -1,6 +1,6 @@
 BeaconState:
   type: object
-  description: "The [`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock) object from the Eth2.0 spec."
+  description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
   properties:
     genesis_time:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -103,7 +103,7 @@ AggregateAndProof:
 
 Aggregate:
   type: object
-  description: "The [`AggregateAndProof`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#aggregateandproof) without selection_proof"
+  description: "The [`AggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#aggregateandproof) without selection_proof"
   properties:
     aggregator_index:
       $ref: './primitive.yaml#/Uint64'
@@ -112,7 +112,7 @@ Aggregate:
 
 
 SignedAggregateAndProof:
-  description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#signedaggregateandproof) object"
+  description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#signedaggregateandproof) object"
   properties:
     message:
       $ref: "#/AggregateAndProof"

--- a/types/voluntary_exit.yaml
+++ b/types/voluntary_exit.yaml
@@ -1,6 +1,6 @@
 VoluntaryExit:
   type: object
-  description: "The [`VoluntaryExit`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#voluntaryexit) object from the Eth2.0 spec."
+  description: "The [`VoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#voluntaryexit) object from the CL spec."
   properties:
     epoch:
       allOf:
@@ -13,7 +13,7 @@ VoluntaryExit:
 
 SignedVoluntaryExit:
   type: object
-  description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the Eth2.0 spec."
+  description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the CL spec."
   properties:
     message:
       $ref: "#/VoluntaryExit"

--- a/validator-flow.md
+++ b/validator-flow.md
@@ -29,7 +29,7 @@ Result are array of objects with validator, his committee and attestation slot.
 
 Attesting:
 1. Upon receiving duty, have beacon node prepare committee subnet
-    - [Check if aggregator by computing `slot_signature`](https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#attestation-aggregation)
+    - [Check if aggregator by computing `slot_signature`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#attestation-aggregation)
     - [Ask beacon node to prepare your subnet](#/ValidatorRequiredApi/prepareBeaconCommitteeSubnet)
       -- Note, validator client only needs to submit one call to
       `prepareBeaconCommitteeSubnet` per committee/slot its validators have


### PR DESCRIPTION
There are still many `eth2.0` references in this repo. For consistency, I've modified the outdated `eth2.0-specs` links to `consensus-specs` and in prose `Eth2.0` to `CL`. 