### PR TITLE
Make oapi license cc0

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -26,8 +26,8 @@ info:
     name: Ethereum Github
     url: https://github.com/ethereum/beacon-apis/issues
   license:
-    name: "Apache 2.0"
-    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+    name: "CC0-1.0"
+    url: "https://creativecommons.org/publicdomain/zero/1.0/"
 
 servers:
   - url: "{server_url}"


### PR DESCRIPTION
The repo is licensed under CC0-1.0, but the oapi is showing it's licensed under Apache 2.0. I updated the oapi spec to be CC0-1.0.