### PR TITLE
Don't produce messages for optimistic blocks

### DIFF
--- a/apis/validator/aggregate_attestation.yaml
+++ b/apis/validator/aggregate_attestation.yaml
@@ -1,7 +1,12 @@
 get:
   operationId: "getAggregatedAttestation"
   summary: "Get aggregated attestation"
-  description: "Aggregates all attestations matching given attestation data root and slot"
+  description: |
+    Aggregates all attestations matching given attestation data root and slot.
+
+    A 503 error must be returned if the block identified by the response
+    `beacon_block_root` is optimistic (i.e. the aggregated attestation attests
+    to a block that has not been fully verified by an execution engine).
   tags:
     - ValidatorRequiredApi
     - Validator

--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -4,7 +4,12 @@ get:
     - Validator
   operationId: "produceAttestationData"
   summary: "Produce an attestation data"
-  description: "Requests that the beacon node produce an AttestationData."
+  description: |
+    Requests that the beacon node produce an AttestationData.
+
+    A 503 error must be returned if the block identified by the response
+    `beacon_block_root` is optimistic (i.e. the attestation attests to a block
+    that has not been fully verified by an execution engine).
   parameters:
     - name: slot
       in: query

--- a/apis/validator/sync_committee_contribution.yaml
+++ b/apis/validator/sync_committee_contribution.yaml
@@ -4,7 +4,12 @@ get:
     - Validator
   operationId: "produceSyncCommitteeContribution"
   summary: "Produce a sync committee contribution"
-  description: "Requests that the beacon node produce a sync committee contribution."
+  description: |
+    Requests that the beacon node produce a sync committee contribution.
+
+    A 503 error must be returned if the block identified by the response
+    `beacon_block_root` is optimistic (i.e. the sync committee contribution
+    refers to a block that has not been fully verified by an execution engine).
   parameters:
     - name: slot
       in: query


### PR DESCRIPTION
This PR ensures that the BN does not produce attestations, aggregate attestations or sync committee contributions that refer to optimistic blocks.

Attesting to an optimistic block is *very bad* and could result in finalizing an invalid execution payload. The changes in this PR mean that the VC doesn't need to check the optimistic status for each object. This saves calls to the API and also protects against faults in VC implementations.

Although sync committee contributions to optimistic blocks couldn't result in an invalid finalized block, it could cause havoc for light clients.