### PR TITLE
fix eth-consensus-version for blinded_block response

### DIFF
--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -36,7 +36,7 @@ get:
       description: Success response
       headers:
         Eth-Consensus-Version:
-          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
       content:
         application/json:
           schema:

--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -34,6 +34,9 @@ get:
   responses:
     "200":
       description: Success response
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
       content:
         application/json:
           schema:


### PR DESCRIPTION
The Eth-consensus-version wasn't listing in the headers for a 200 response like it was in get new block, so making it consistent here.