### PR TITLE
Optional randao verification when producing blocks

### DIFF
--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -28,6 +28,15 @@ get:
       description: "Arbitrary data validator wants to include in block."
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Graffiti'
+    - name: skip_randao_verification
+      in: query
+      required: false
+      description: |
+        Skip verification of the `randao_reveal` value. If this flag is set then the
+        `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter
+        is a flag and does not take a value.
+      schema: {}
+      allowEmptyValue: true
   responses:
     "200":
       description: Success response


### PR DESCRIPTION
Recently I've been speculatively creating blocks using the `/eth/v2/validator/blocks/{slot}` endpoint, polling the endpoint live at every slot.

Some beacon node implementations verify the `randao_reveal` signature when this endpoint is used, which causes speculative block proposal to fail (because the private key for the true `proposer_index` is not known).

A few months ago I added an optional `verify_randao` parameter to disable the verification in Lighthouse: https://github.com/sigp/lighthouse/pull/3116. Recently I've discovered that Nimbus have started to verify the `randao_reveal` by default too, so I'd like to implore them to adopt the same parameter.

As far as I know the other clients (Teku/Prysm/Lodestar) don't verify the `randao_reveal` currently, so I think it would be acceptable for them to delay implementing the `verify_randao` parameter until they decide to. Alternatively they could maintain the same semantics and accept `verify_randao=false/null`, and error if `verify_randao=true`. I would like to impose the minimum burden on implementers, given that this is a relatively niche use case.

More background:

- Blockdreamer: https://github.com/michaelsproul/blockdreamer
- My use for blockdreamer: https://twitter.com/sproulM_/status/1543422741218439170