### PR TITLE
Fix config spec schema example

### DIFF
--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -29,11 +29,11 @@ get:
                     - any value starting with 0x in the spec is returned as a hex string
                     - numeric values are returned as a quoted integer
                 type: object
-            example:
-              'DEPOSIT_CONTRACT_ADDRESS': '0x00000000219ab540356cBB839Cbe05303d7705Fa'
-              'DEPOSIT_NETWORK_ID': '1'
-              'DOMAIN_AGGREGATE_AND_PROOF': '0x06000000'
-              'INACTIVITY_PENALTY_QUOTIENT': '67108864'
-              'INACTIVITY_PENALTY_QUOTIENT_ALTAIR': '50331648'
+                example:
+                  'DEPOSIT_CONTRACT_ADDRESS': '0x00000000219ab540356cBB839Cbe05303d7705Fa'
+                  'DEPOSIT_NETWORK_ID': '1'
+                  'DOMAIN_AGGREGATE_AND_PROOF': '0x06000000'
+                  'INACTIVITY_PENALTY_QUOTIENT': '67108864'
+                  'INACTIVITY_PENALTY_QUOTIENT_ALTAIR': '50331648'
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError


### PR DESCRIPTION
The example section for the `/eth/v1/config/spec` endpoint does not have the correct padding and it gets [rendered](https://ethereum.github.io/beacon-APIs/#/Config/getSpec) as:
```
{
   "DEPOSIT_CONTRACT_ADDRESS": ""
}
```
instead of:
```
{
   "data": {
       "DEPOSIT_CONTRACT_ADDRESS": ""
   }
}
```