### PR TITLE
Use the correct primitive for Graffiti

### DIFF
--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -31,8 +31,7 @@ Altair:
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:
-        type: string
-        pattern: "^0x[a-fA-F0-9]{64}$"
+        $ref: '../primitive.yaml#/Graffiti'
       proposer_slashings:
         type: array
         items:

--- a/types/bellatrix/block.yaml
+++ b/types/bellatrix/block.yaml
@@ -11,8 +11,7 @@ Bellatrix:
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:
-        type: string
-        pattern: "^0x[a-fA-F0-9]{64}$"
+        $ref: '../primitive.yaml#/Graffiti'
       proposer_slashings:
         type: array
         items:

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -30,8 +30,7 @@ BeaconBlockBody:
     eth1_data:
       $ref: './eth1.yaml#/Eth1Data'
     graffiti:
-      type: string
-      pattern: "^0x[a-fA-F0-9]{64}$"
+      $ref: "./primitive.yaml#/Graffiti"
     proposer_slashings:
       type: array
       items:


### PR DESCRIPTION
This PR uses the `Graffiti` primitive in the `BeaconBlock` objects.