### PR TITLE
Registrations for exited or unknown validators will not be sent to the builder network

### DIFF
--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -10,8 +10,8 @@ post:
     blocks that do not adhere to their latest fee recipient and gas limit
     preferences.
 
-    Note that requests containing currently inactive or unknown validator
-    pubkeys will be accepted, as they may become active at a later epoch.
+    Note that requests must not contain exited validator pubkeys. However, requests may contain inactive or unknown validator
+    pubkeys, as they may become active at a later epoch.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -10,8 +10,8 @@ post:
     blocks that do not adhere to their latest fee recipient and gas limit
     preferences.
 
-    Note that requests must not contain exited validator pubkeys. However, requests may contain inactive or unknown validator
-    pubkeys, as they may become active at a later epoch.
+    Note that exited validator registrations will be filtered out and not sent to the builder network. However, inactive or unknown validator
+    registrations will be sent, as these validators may become active at a later epoch.
   tags:
     - Validator
   requestBody:
@@ -20,11 +20,11 @@ post:
         schema:
           type: array
           items:
-              $ref: '../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration'
+            $ref: "../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration"
   responses:
     "200":
       description: Registration information has been received.
     "400":
-      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+      $ref: "../../beacon-node-oapi.yaml#/components/responses/InvalidRequest"
     "500":
-      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
+      $ref: "../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -11,7 +11,7 @@ post:
     preferences.
 
     Note that registrations for exited validators will be filtered out and not sent to the builder network. 
-    However, registrations for inactive or unknown validators will be sent, as these validators may become active at a later epoch.
+    However, registrations for inactive or unknown validators will be sent, as they may become active at a later epoch.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -10,8 +10,8 @@ post:
     blocks that do not adhere to their latest fee recipient and gas limit
     preferences.
 
-    Note that exited validator registrations will be filtered out and not sent to the builder network. However, inactive or unknown validator
-    registrations will be sent, as these validators may become active at a later epoch.
+    Note that registrations for exited validators will be filtered out and not sent to the builder network. 
+    However, registrations for inactive or unknown validators will be sent, as these validators may become active at a later epoch.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -3,15 +3,15 @@ post:
   summary: Provide beacon node with registrations for the given validators to the external builder network.
   description: |
     Prepares the beacon node for engaging with external builders. The
-    information will be sent by the beacon node to the builder network. It is
+    information must be sent by the beacon node to the builder network. It is
     expected that the validator client will send this information periodically
     to ensure the beacon node has correct and timely registration information
     to provide to builders. The validator client should not sign blinded beacon
     blocks that do not adhere to their latest fee recipient and gas limit
     preferences.
 
-    Note that only registrations for active or pending validators will be sent to the builder network.
-    Registrations for unknown or exited validators will be filtered out and not sent to the builder network.
+    Note that only registrations for active or pending validators must be sent to the builder network.
+    Registrations for unknown or exited validators must be filtered out and not sent to the builder network.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -10,8 +10,8 @@ post:
     blocks that do not adhere to their latest fee recipient and gas limit
     preferences.
 
-    Note that registrations for exited validators will be filtered out and not sent to the builder network. 
-    However, registrations for inactive or unknown validators will be sent, as they may become active at a later epoch.
+    Note that only registrations for active or pending validators will be sent to the builder network.
+    Registrations for exited validators will be filtered out and not sent to the builder network.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -11,7 +11,7 @@ post:
     preferences.
 
     Note that only registrations for active or pending validators will be sent to the builder network.
-    Registrations for exited validators will be filtered out and not sent to the builder network.
+    Registrations for unknown or exited validators will be filtered out and not sent to the builder network.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -20,11 +20,11 @@ post:
         schema:
           type: array
           items:
-            $ref: "../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration"
+            $ref: '../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration'
   responses:
     "200":
       description: Registration information has been received.
     "400":
-      $ref: "../../beacon-node-oapi.yaml#/components/responses/InvalidRequest"
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "500":
-      $ref: "../../beacon-node-oapi.yaml#/components/responses/InternalError"
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'


### PR DESCRIPTION
Clarify in the `registerValidator` description that registrations for `exited` or unknown validators will not be sent to the builder network.

Related to https://github.com/flashbots/mev-boost/issues/245