### PR TITLE
Remove format: hex

### DIFF
--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -55,7 +55,6 @@ Bytes32:
 
 Graffiti:
   type: string
-  format: hex
   example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
   pattern: "^0x[a-fA-F0-9]{64}$"
 


### PR DESCRIPTION
Not specified as valid format in openapi https://swagger.io/docs/specification/data-models/data-types/

Makes [AJV](https://ajv.js.org) throw error on schema validation "format unknown"