### PR TITLE
Remove allOf usage where property merging is not necessary

### DIFF
--- a/apis/beacon/blocks/headers.yaml
+++ b/apis/beacon/blocks/headers.yaml
@@ -9,17 +9,13 @@ get:
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
     - name: parent_root
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"
-          - example: ""
-  
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"
+
   responses:
     "200":
       description: Success

--- a/apis/beacon/blocks/root.yaml
+++ b/apis/beacon/blocks/root.yaml
@@ -30,9 +30,8 @@ get:
                 type: object
                 properties:
                   root:
-                    allOf:
-                      - description: HashTreeRoot of BeaconBlock/BeaconBlockHeader object
-                      - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                    $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                    description: HashTreeRoot of BeaconBlock/BeaconBlockHeader object
     "400":
       description: "The block ID supplied could not be parsed"
       content:

--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -7,7 +7,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: "../../../beacon-node-oapi.yaml#/components/parameters/StateId"
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: epoch
       description: "Fetch committees for the given epoch.  If not present then the committees for the epoch of the state will be obtained."
       in: query
@@ -41,7 +41,7 @@ get:
               data:
                 type: array
                 items:
-                  $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Committee"
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Committee'
     "400":
       description: "Invalid state ID, index, epoch, slot, or combination thereof"
       content:

--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -7,32 +7,26 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+      $ref: "../../../beacon-node-oapi.yaml#/components/parameters/StateId"
     - name: epoch
       description: "Fetch committees for the given epoch.  If not present then the committees for the epoch of the state will be obtained."
       in: query
       required: false
       allowEmptyValue: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
     - name: index
       description: "Restrict returned values to those matching the supplied committee index."
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
     - name: slot
       description: "Restrict returned values to those matching the supplied slot."
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
   responses:
     "200":
       description: Success
@@ -47,7 +41,7 @@ get:
               data:
                 type: array
                 items:
-                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Committee'
+                  $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Committee"
     "400":
       description: "Invalid state ID, index, epoch, slot, or combination thereof"
       content:

--- a/apis/beacon/states/root.yaml
+++ b/apis/beacon/states/root.yaml
@@ -23,9 +23,8 @@ get:
                 type: object
                 properties:
                   root:
-                    allOf:
-                      - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
-                      - description: HashTreeRoot of BeaconState object
+                    $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                    description: HashTreeRoot of BeaconState object
     "400":
       description: "Invalid state ID"
       content:

--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -7,16 +7,14 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+      $ref: "../../../beacon-node-oapi.yaml#/components/parameters/StateId"
     - name: epoch
       description: "Fetch sync committees for the given epoch.  If not present then the sync committees for the epoch of the state will be obtained."
       in: query
       required: false
       allowEmptyValue: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
   responses:
     "200":
       description: Success
@@ -29,7 +27,7 @@ get:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
               data:
-                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommittee'
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommittee"
 
     "400":
       description: "Invalid state ID or epoch"

--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -7,7 +7,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: "../../../beacon-node-oapi.yaml#/components/parameters/StateId"
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: epoch
       description: "Fetch sync committees for the given epoch.  If not present then the sync committees for the epoch of the state will be obtained."
       in: query
@@ -27,7 +27,7 @@ get:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
               data:
-                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommittee"
+                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommittee'
 
     "400":
       description: "Invalid state ID or epoch"

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -13,7 +13,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: "../../../beacon-node-oapi.yaml#/components/parameters/StateId"
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
     - name: id
       description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
       in: query
@@ -49,7 +49,7 @@ get:
               data:
                 type: array
                 items:
-                  $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse"
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse'
     "400":
       description: "Invalid state or validator ID, or status"
       content:

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -13,7 +13,7 @@ get:
   parameters:
     - name: state_id
       in: path
-      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+      $ref: "../../../beacon-node-oapi.yaml#/components/parameters/StateId"
     - name: id
       description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
       in: query
@@ -33,9 +33,7 @@ get:
         type: array
         uniqueItems: true
         items:
-          allOf:
-            - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus'
-            - enum: ["active", "pending", "exited", "withdrawal"]
+          $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus"
 
   responses:
     "200":
@@ -51,7 +49,7 @@ get:
               data:
                 type: array
                 items:
-                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse'
+                  $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse"
     "400":
       description: "Invalid state or validator ID, or status"
       content:

--- a/apis/config/deposit_contract.yaml
+++ b/apis/config/deposit_contract.yaml
@@ -17,14 +17,11 @@ get:
                 type: object
                 properties:
                   chain_id:
-                    allOf:
-                      - $ref: ../../beacon-node-oapi.yaml#/components/schemas/Uint64
-                      - description: Id of Eth1 chain on which contract is deployed.
-                      - example: "1"
+                    $ref: ../../beacon-node-oapi.yaml#/components/schemas/Uint64
+                    description: Id of Eth1 chain on which contract is deployed.
                   address:
-                    allOf:
-                      - $ref: ../../beacon-node-oapi.yaml#/components/schemas/Hex
-                      - description: Hex encoded deposit contract address with 0x prefix
-                      - example: "0x1Db3439a222C519ab44bb1144fC28167b4Fa6EE6"
+                    $ref: ../../beacon-node-oapi.yaml#/components/schemas/Hex
+                    description: Hex encoded deposit contract address with 0x prefix
+                    example: "0x1Db3439a222C519ab44bb1144fC28167b4Fa6EE6"
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError

--- a/apis/node/peer_count.yaml
+++ b/apis/node/peer_count.yaml
@@ -15,22 +15,18 @@ get:
             properties:
               data:
                 type: object
-                properties: 
+                properties:
                   disconnected:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "12"
+                    $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                    example: "12"
                   connecting:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "34"
+                    $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                    example: "34"
                   connected:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "56"
+                    $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                    example: "56"
                   disconnecting:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "5"
+                    $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                    example: "5"
     "500":
-      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
+      $ref: "../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/node/peer_count.yaml
+++ b/apis/node/peer_count.yaml
@@ -15,7 +15,7 @@ get:
             properties:
               data:
                 type: object
-                properties:
+                properties: 
                   disconnected:
                     $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     example: "12"
@@ -29,4 +29,4 @@ get:
                     $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     example: "5"
     "500":
-      $ref: "../../beacon-node-oapi.yaml#/components/responses/InternalError"
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/node/syncing.yaml
+++ b/apis/node/syncing.yaml
@@ -18,21 +18,17 @@
                   type: object
                   properties:
                     head_slot:
-                      allOf:
-                        - description: "Head slot node is trying to reach"
-                        - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                      description: "Head slot node is trying to reach"
+                      $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     sync_distance:
-                      allOf:
-                        - description: "How many slots node needs to process to reach head. 0 if synced."
-                        - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                      description: "How many slots node needs to process to reach head. 0 if synced."
+                      $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     is_syncing:
-                      allOf:
-                        - type: boolean
-                        - description: "Set to true if the node is syncing, false if the node is synced."
+                      type: boolean
+                      description: "Set to true if the node is syncing, false if the node is synced."
                     is_optimistic:
-                      allOf:
-                        - type: boolean
-                        - description: "Set to true if the node is optimistically tracking head."
+                      type: boolean
+                      description: "Set to true if the node is optimistically tracking head."
 
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -25,13 +25,11 @@ post:
               committee_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               committees_at_slot:
-                allOf:
-                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                  - description: "Number of committees at the returned slot"
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                description: "Number of committees at the returned slot"
               slot:
-                allOf:
-                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                  - description: "Should be slot at which validator is assigned to attest"
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                description: "Should be slot at which validator is assigned to attest"
               is_aggregator:
                 type: boolean
                 description: "Signals to BN that a validator on the VC has been chosen for aggregator role."

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -29,9 +29,9 @@ post:
             type: object
             properties:
               validator_index:
-                $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               fee_recipient:
-                $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress"
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress'
   responses:
     "200":
       description: |

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -29,9 +29,9 @@ post:
             type: object
             properties:
               validator_index:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
               fee_recipient:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress'
+                $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress"
   responses:
     "200":
       description: |

--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -4,30 +4,25 @@ Altair:
     type: object
     properties:
       slot:
-        allOf:
-          - $ref: "../primitive.yaml#/Uint64"
-          - description: "The slot to which this block corresponds."
+        $ref: "../primitive.yaml#/Uint64"
+        description: "The slot to which this block corresponds."
       proposer_index:
-        allOf:
-          - $ref: '../primitive.yaml#/Uint64'
-          - description: "Index of validator in validator registry."
+        $ref: '../primitive.yaml#/Uint64'
+        description: "Index of validator in validator registry."
       parent_root:
-        allOf:
-          - $ref: '../primitive.yaml#/Root'
-          - description: "The signing merkle root of the parent `BeaconBlock`."
+        $ref: '../primitive.yaml#/Root'
+        description: "The signing merkle root of the parent `BeaconBlock`."
       state_root:
-        allOf:
-          - $ref: '../primitive.yaml#/Root'
-          - description: "The tree hash merkle root of the `BeaconState` for the `BeaconBlock`."
+        $ref: '../primitive.yaml#/Root'
+        description: "The tree hash merkle root of the `BeaconState` for the `BeaconBlock`."
 
   BeaconBlockBody:
     type: object
     description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblockbody) object from the CL Altair spec."
     properties:
       randao_reveal:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: "The RanDAO reveal value provided by the validator."
+        $ref: '../primitive.yaml#/Signature'
+        description: "The RanDAO reveal value provided by the validator."
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:

--- a/types/altair/epoch_participation.yaml
+++ b/types/altair/epoch_participation.yaml
@@ -2,6 +2,5 @@ Altair:
   EpochParticipation:
     type: array
     items:
-      allOf:
-        - $ref: '../primitive.yaml#/Uint8'
+      $ref: '../primitive.yaml#/Uint8'
     maxItems: 1099511627776

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -16,30 +16,26 @@ Altair:
       block_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         minItems: 8192
         maxItems: 8192
       state_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         minItems: 8192
         maxItems: 8192
       historical_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         maxItems: 16777216
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
         type: array
         items:
-          allOf:
-            - $ref: '../eth1.yaml#/Eth1Data'
+          $ref: '../eth1.yaml#/Eth1Data'
         maxItems: 1024
       eth1_deposit_index:
         $ref: "../primitive.yaml#/Uint64"
@@ -47,28 +43,24 @@ Altair:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../validator.yaml#/Validator'
+          $ref: '../validator.yaml#/Validator'
       balances:
         type: array
         description: "Validator balances in gwei"
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Bytes32'
+          $ref: '../primitive.yaml#/Bytes32'
         minItems: 65536
         maxItems: 65536
       slashings:
         type: array
         description: "Per-epoch sums of slashed effective balances"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
         minItems: 8192
         maxItems: 8192
       previous_epoch_participation:
@@ -91,8 +83,7 @@ Altair:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: "../primitive.yaml#/Uint64"
+          $ref: "../primitive.yaml#/Uint64"
       current_sync_committee:
         $ref: "./sync_committee.yaml#/Altair/SyncCommittee"
       next_sync_committee:

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -5,8 +5,7 @@ Altair:
       pubkeys:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Pubkey'
+          $ref: '../primitive.yaml#/Pubkey'
         minItems: 512
         maxItems: 512
       aggregate_pubkey:
@@ -30,12 +29,10 @@ Altair:
       sync_committee_indices:
         type: array
         items:
-          allOf:
-           - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
       until_epoch:
-        allOf:
-         - $ref: '../primitive.yaml#/Uint64'
-         - description: 'The final epoch (exclusive value) that the specified validator requires the subscription for.'
+        $ref: '../primitive.yaml#/Uint64'
+        description: 'The final epoch (exclusive value) that the specified validator requires the subscription for.'
          
   SignedContributionAndProof:
     type: object
@@ -49,9 +46,8 @@ Altair:
     type: object
     properties:
       aggregator_index:
-        allOf:
-          - $ref: "../primitive.yaml#/Uint64"
-          - description: "Index of validator in validator registry."
+        $ref: "../primitive.yaml#/Uint64"
+        description: "Index of validator in validator registry."
       selection_proof:
         $ref: '../primitive.yaml#/Signature'
       contribution:
@@ -61,42 +57,34 @@ Altair:
     type: object
     properties:
       slot:
-        allOf:
-          - $ref: "../primitive.yaml#/Uint64"
-          - description: "The slot at which the validator is providing a sync committee contribution."
+        $ref: "../primitive.yaml#/Uint64"
+        description: "The slot at which the validator is providing a sync committee contribution."
       beacon_block_root:
-        allOf:
-          - $ref: '../primitive.yaml#/Root'
-          - description: "Block root for this contribution."
+        $ref: '../primitive.yaml#/Root'
+        description: "Block root for this contribution."
       subcommittee_index:
-        allOf:
-          - $ref: '../primitive.yaml#/Uint64'
-          - description: 'The index of the subcommittee that the contribution pertains to.'
+        $ref: '../primitive.yaml#/Uint64'
+        description: 'The index of the subcommittee that the contribution pertains to.'
       aggregation_bits:
-        allOf:
-          - description: 'A bit is set if a signature from the validator at the corresponding index in the subcommittee is present in the aggregate `signature`.'
-          - $ref: "../primitive.yaml#/Hex"
-          - example: "0x01"
+        $ref: "../primitive.yaml#/Hex"
+        description: 'A bit is set if a signature from the validator at the corresponding index in the subcommittee is present in the aggregate `signature`.'
+        example: "0x01"
       signature:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: 'Signature by the validator(s) over the block root of `slot`'
+        $ref: '../primitive.yaml#/Signature'
+        description: 'Signature by the validator(s) over the block root of `slot`'
   ValidatorsByIndex:
     type: array
     items:
-      allOf:
-        - $ref: '../primitive.yaml#/Uint64'
+      $ref: '../primitive.yaml#/Uint64'
   SyncCommitteeByValidatorIndices:
     type: object
     properties:
       validators:
-        allOf:
-         - $ref: '#/Altair/ValidatorsByIndex'
-         - description: 'all of the validator indices in the current sync committee'
+        $ref: '#/Altair/ValidatorsByIndex'
+        description: 'all of the validator indices in the current sync committee'
       validator_aggregates:
         type: array
         items:
-          allOf:
-            - $ref: '#/Altair/ValidatorsByIndex'
-            - description: 'Subcommittee slices of the current sync committee'
+          $ref: '#/Altair/ValidatorsByIndex'
+          description: 'Subcommittee slices of the current sync committee'
 

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -4,13 +4,11 @@ ValidatorResponse:
   type: object
   properties:
     index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of validator in validator registry."
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
     balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Current validator balance in gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Current validator balance in gwei."
     status:
       $ref: "#/ValidatorStatus"
     validator:
@@ -20,13 +18,11 @@ ValidatorBalanceResponse:
   type: object
   properties:
     index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of validator in validator registry."
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
     balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Current validator balance in gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Current validator balance in gwei."
 
 ValidatorStatus:
   description: |
@@ -51,9 +47,8 @@ Committee:
   type: object
   properties:
     index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: Committee index at a slot
+      $ref: './primitive.yaml#/Uint64'
+      description: Committee index at a slot
     slot:
       $ref: './primitive.yaml#/Uint64'
 

--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -9,9 +9,8 @@ IndexedAttestation:
       items:
         $ref: "./primitive.yaml#/Uint64"
     signature:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "The BLS signature of the `IndexedAttestation`, created by the validator of the attestation."
+      $ref: './primitive.yaml#/Signature'
+      description: "The BLS signature of the `IndexedAttestation`, created by the validator of the attestation."
     data:
       $ref: './attestation.yaml#/AttestationData'
 
@@ -25,9 +24,8 @@ Attestation:
       pattern: "^0x[a-fA-F0-9]+$"
       description: "Attester aggregation bits."
     signature:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "BLS aggregate signature."
+      $ref: './primitive.yaml#/Signature'
+      description: "BLS aggregate signature."
     data:
       $ref: './attestation.yaml#/AttestationData'
 
@@ -55,9 +53,8 @@ AttestationData:
     index:
       $ref: "./primitive.yaml#/Uint64"
     beacon_block_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "LMD GHOST vote."
+      $ref: './primitive.yaml#/Root'
+      description: "LMD GHOST vote."
     source:
       $ref: "./misc.yaml#/Checkpoint"
     target:

--- a/types/bellatrix/block.yaml
+++ b/types/bellatrix/block.yaml
@@ -5,9 +5,8 @@ Bellatrix:
     description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec."
     properties:
       randao_reveal:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: "The RanDAO reveal value provided by the validator."
+        $ref: '../primitive.yaml#/Signature'
+        description: "The RanDAO reveal value provided by the validator."
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -16,30 +16,26 @@ Bellatrix:
       block_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         minItems: 8192
         maxItems: 8192
       state_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         minItems: 8192
         maxItems: 8192
       historical_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         maxItems: 16777216
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
         type: array
         items:
-          allOf:
-            - $ref: '../eth1.yaml#/Eth1Data'
+          $ref: '../eth1.yaml#/Eth1Data'
         maxItems: 1024
       eth1_deposit_index:
         $ref: "../primitive.yaml#/Uint64"
@@ -47,28 +43,24 @@ Bellatrix:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../validator.yaml#/Validator'
+          $ref: '../validator.yaml#/Validator'
       balances:
         type: array
         description: "Validator balances in gwei"
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Bytes32'
+          $ref: '../primitive.yaml#/Bytes32'
         minItems: 65536
         maxItems: 65536
       slashings:
         type: array
         description: "Per-epoch sums of slashed effective balances"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
         minItems: 8192
         maxItems: 8192
       previous_epoch_participation:
@@ -91,8 +83,7 @@ Bellatrix:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: "../primitive.yaml#/Uint64"
+          $ref: "../primitive.yaml#/Uint64"
       current_sync_committee:
         $ref: "../altair/sync_committee.yaml#/Altair/SyncCommittee"
       next_sync_committee:

--- a/types/bellatrix/transactions.yaml
+++ b/types/bellatrix/transactions.yaml
@@ -2,6 +2,5 @@ Bellatrix:
   Transactions:
       type: array
       items:
-        allOf:
-          - $ref: '../primitive.yaml#/Transaction'
+        $ref: '../primitive.yaml#/Transaction'
       maxItems: 1048576

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -3,30 +3,25 @@ BeaconBlockCommon:
   type: object
   properties:
     slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The slot to which this block corresponds."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The slot to which this block corresponds."
     proposer_index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of validator in validator registry."
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
     parent_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The signing merkle root of the parent `BeaconBlock`."
+      $ref: './primitive.yaml#/Root'
+      description: "The signing merkle root of the parent `BeaconBlock`."
     state_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The tree hash merkle root of the `BeaconState` for the `BeaconBlock`."
+      $ref: './primitive.yaml#/Root'
+      description: "The tree hash merkle root of the `BeaconState` for the `BeaconBlock`."
 
 BeaconBlockBody:
   type: object
   description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockbody) object from the CL spec."
   properties:
     randao_reveal:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "The RanDAO reveal value provided by the validator."
+      $ref: './primitive.yaml#/Signature'
+      description: "The RanDAO reveal value provided by the validator."
     eth1_data:
       $ref: './eth1.yaml#/Eth1Data'
     graffiti:
@@ -78,9 +73,8 @@ BeaconBlockHeader:
     - type: object
       properties:
         body_root:
-          allOf:
-            - $ref: './primitive.yaml#/Root'
-            - description: "The tree hash merkle root of the `BeaconBlockBody` for the `BeaconBlock`"
+          $ref: './primitive.yaml#/Root'
+          description: "The tree hash merkle root of the `BeaconBlockBody` for the `BeaconBlock`"
 
 SignedBeaconBlockHeader:
   type: object

--- a/types/deposit.yaml
+++ b/types/deposit.yaml
@@ -6,8 +6,7 @@ Deposit:
       type: array
       description: "Branch in the deposit tree."
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
       minItems: 32
       maxItems: 32
     data:
@@ -19,14 +18,11 @@ DepositData:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     withdrawal_credentials:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The withdrawal credentials."
+      $ref: './primitive.yaml#/Root'
+      description: "The withdrawal credentials."
     amount:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Amount in Gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Amount in Gwei."
     signature:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "Container self-signature."
+      $ref: './primitive.yaml#/Signature'
+      description: "Container self-signature."

--- a/types/eth1.yaml
+++ b/types/eth1.yaml
@@ -3,14 +3,11 @@ Eth1Data:
   description: "The [`Eth1Data`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#eth1data) object from the CL spec."
   properties:
     deposit_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "Root of the deposit tree."
+      $ref: './primitive.yaml#/Root'
+      description: "Root of the deposit tree."
     deposit_count:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Total number of deposits."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Total number of deposits."
     block_hash:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "Ethereum 1.x block hash."
+      $ref: './primitive.yaml#/Root'
+      description: "Ethereum 1.x block hash."

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -8,16 +8,14 @@ NetworkIdentity:
     p2p_addresses:
       type: array
       items:
-        allOf:
-          - $ref: "./p2p.yaml#/Multiaddr"
-          - description: "Node's addresses on which eth2 rpc requests are served. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
+        $ref: "./p2p.yaml#/Multiaddr"
+        description: "Node's addresses on which eth2 rpc requests are served. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
     discovery_addresses:
       type: array
       items:
-        allOf:
-          - $ref: "./p2p.yaml#/Multiaddr"
-          - description: "Node's addresses on which is listening for discv5 requests. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
-          - example: "/ip4/7.7.7.7/udp/30303/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
+        $ref: "./p2p.yaml#/Multiaddr"
+        description: "Node's addresses on which is listening for discv5 requests. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
+        example: "/ip4/7.7.7.7/udp/30303/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
     metadata:
       $ref: "./p2p.yaml#/MetaData"
 
@@ -27,19 +25,16 @@ MetaData:
   required: ["seq_number", "attnets"]
   properties:
     seq_number:
-      allOf:
-        - description: "Uint64 starting at 0 used to version the node's metadata. If any other field in the local MetaData changes, the node MUST increment seq_number by 1."
-        - $ref: "./primitive.yaml#/Uint64"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Uint64 starting at 0 used to version the node's metadata. If any other field in the local MetaData changes, the node MUST increment seq_number by 1."
     attnets:
-      allOf:
-        - description: "Bitvector representing the node's persistent attestation subnet subscriptions."
-        - $ref: "./primitive.yaml#/Hex"
-        - example: "0x0000000000000000"
+      $ref: "./primitive.yaml#/Hex"
+      description: "Bitvector representing the node's persistent attestation subnet subscriptions."
+      example: "0x0000000000000000"
     syncnets:
-      allOf:
-        - description: "Bitvector representing the node's sync committee subnet subscriptions. This metadata is not present in phase0, but will be present in Altair."
-        - $ref: "./primitive.yaml#/Hex"
-        - example: "0x0f"
+      $ref: "./primitive.yaml#/Hex"
+      description: "Bitvector representing the node's sync committee subnet subscriptions. This metadata is not present in phase0, but will be present in Altair."
+      example: "0x0f"
 
 Peer:
   type: object
@@ -47,13 +42,11 @@ Peer:
     peer_id:
       $ref: "./p2p.yaml#/PeerId"
     enr:
-      allOf:
-        - $ref: "./p2p.yaml#/ENR"
-        - nullable: true
+      $ref: "./p2p.yaml#/ENR"
+      nullable: true
     last_seen_p2p_address:
-      allOf:
-        - $ref: "./p2p.yaml#/Multiaddr"
-        - description: Multiaddrs used in last peer connection.
+      $ref: "./p2p.yaml#/Multiaddr"
+      description: Multiaddrs used in last peer connection.
     state:
       $ref: "./p2p.yaml#/PeerConnectionState"
     direction:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -16,10 +16,9 @@ Version:
   example: "Lighthouse/v0.1.5 (Linux x86_64)"
 
 GenesisTime:
-  allOf:
-    - $ref: "./primitive.yaml#/Uint64"
-    - example: "1590832934"
-    - description: "The genesis_time configured for the beacon node, which is the unix time in seconds at which the Eth2.0 chain began."
+  $ref: "./primitive.yaml#/Uint64"
+  example: "1590832934"
+  description: "The genesis_time configured for the beacon node, which is the unix time in seconds at which the Eth2.0 chain began."
 
 Gwei:
   $ref: "./primitive.yaml#/Uint64"
@@ -33,15 +32,13 @@ Uint256:
   example: "1"
 
 DependentRoot:
-  allOf:
-    - $ref: "./primitive.yaml#/Root"
-    - description: "The block root that this response is dependent on."
+  $ref: "./primitive.yaml#/Root"
+  description: "The block root that this response is dependent on."
 
 ExecutionOptimistic:
-  allOf:
-    - type: boolean
-    - example: false
-    - description: "True if the response references an unverified execution payload. Optimistic information may be invalidated at a later time. If the field is not present, assume the False value."
+  type: boolean
+  example: false
+  description: "True if the response references an unverified execution payload. Optimistic information may be invalidated at a later time. If the field is not present, assume the False value."
 
 Root:
   type: string

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -15,30 +15,26 @@ BeaconState:
     block_roots:
       type: array
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
       minItems: 8192
       maxItems: 8192
     state_roots:
       type: array
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
       minItems: 8192
       maxItems: 8192
     historical_roots:
       type: array
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
       maxItems: 16777216
     eth1_data:
       $ref: "./eth1.yaml#/Eth1Data"
     eth1_data_votes:
       type: array
       items:
-        allOf:
-          - $ref: './eth1.yaml#/Eth1Data'
+        $ref: './eth1.yaml#/Eth1Data'
       maxItems: 1024
     eth1_deposit_index:
       $ref: "./primitive.yaml#/Uint64"
@@ -46,40 +42,34 @@ BeaconState:
       type: array
       maxItems: 1099511627776
       items:
-        allOf:
-          - $ref: './validator.yaml#/Validator'
+        $ref: './validator.yaml#/Validator'
     balances:
       type: array
       description: "Validator balances in gwei"
       maxItems: 1099511627776
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Uint64'
+        $ref: './primitive.yaml#/Uint64'
     randao_mixes:
       type: array
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Bytes32'
+        $ref: './primitive.yaml#/Bytes32'
       minItems: 65536
       maxItems: 65536
     slashings:
       type: array
       description: "Per-epoch sums of slashed effective balances"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Uint64'
+        $ref: './primitive.yaml#/Uint64'
       minItems: 8192
       maxItems: 8192
     previous_epoch_attestations:
       type: array
       items:
-        allOf:
-          - $ref: './attestation.yaml#/PendingAttestation'
+        $ref: './attestation.yaml#/PendingAttestation'
     current_epoch_attestations:
       type: array
       items:
-        allOf:
-          - $ref: './attestation.yaml#/PendingAttestation'
+        $ref: './attestation.yaml#/PendingAttestation'
     justification_bits:
       type: string
       pattern: "^0x[a-fA-F0-9]+$"

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -4,33 +4,27 @@ Validator:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     withdrawal_credentials:
-      allOf:
-        - $ref: "./primitive.yaml#/Root"
-        - description: "Root of withdrawal credentials"
+      $ref: "./primitive.yaml#/Root"
+      description: "Root of withdrawal credentials"
     effective_balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Balance at stake in Gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Balance at stake in Gwei."
     slashed:
       type: boolean
       example: false
       description: "Was validator slashed (not longer active)."
     activation_eligibility_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "When criteria for activation were met."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "When criteria for activation were met."
     activation_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Epoch when validator activated. 'FAR_FUTURE_EPOCH' if not activated"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Epoch when validator activated. 'FAR_FUTURE_EPOCH' if not activated"
     exit_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Epoch when validator exited. 'FAR_FUTURE_EPOCH' if not exited."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Epoch when validator exited. 'FAR_FUTURE_EPOCH' if not exited."
     withdrawable_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "When validator can withdraw or transfer funds. 'FAR_FUTURE_EPOCH' if not defined"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "When validator can withdraw or transfer funds. 'FAR_FUTURE_EPOCH' if not defined"
 
 AttesterDuty:
   type: object
@@ -38,29 +32,23 @@ AttesterDuty:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     validator_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of validator in validator registry"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of validator in validator registry"
     committee_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The committee index"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The committee index"
     committee_length:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Number of validators in committee"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Number of validators in committee"
     committees_at_slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Number of committees at the provided slot"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Number of committees at the provided slot"
     validator_committee_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of validator in committee"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of validator in committee"
     slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The slot at which the validator must attest."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The slot at which the validator must attest."
 
 ProposerDuty:
   type: object
@@ -68,13 +56,11 @@ ProposerDuty:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     validator_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of validator in validator registry."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of validator in validator registry."
     slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The slot at which the validator must propose block."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The slot at which the validator must propose block."
 
 Altair:
   SyncDuty:
@@ -83,9 +69,8 @@ Altair:
       pubkey:
         $ref: './primitive.yaml#/Pubkey'
       validator_index:
-        allOf:
-          - $ref: "./primitive.yaml#/Uint64"
-          - description: "Index of validator in validator registry."
+        $ref: "./primitive.yaml#/Uint64"
+        description: "Index of validator in validator registry."
       validator_sync_committee_indices:
         type: array
         description: "The indices of the validator in the sync committee."

--- a/types/voluntary_exit.yaml
+++ b/types/voluntary_exit.yaml
@@ -3,13 +3,11 @@ VoluntaryExit:
   description: "The [`VoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#voluntaryexit) object from the CL spec."
   properties:
     epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Minimum epoch for processing exit."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Minimum epoch for processing exit."
     validator_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of the exiting validator."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of the exiting validator."
 
 SignedVoluntaryExit:
   type: object


### PR DESCRIPTION
The build step done on build resolves all $ref references.

https://github.com/ethereum/beacon-APIs/blob/9cab46ad3c94a4a2779b42fa21f6bb1955b60b56/.github/workflows/main.yml#L18

If a property is specified both in the $ref and the existing schema the latter overrides $ref without needing allOf syntax. So
- If you need to override the description property or add a new example, no need for allOf
- If you need to merge object "properties" you need allOf to perform deep merging at runtime

Related to https://github.com/ethereum/beacon-APIs/pull/235
Closes https://github.com/ethereum/beacon-APIs/issues/237