### PR TITLE
Add format hex to hex strings

### DIFF
--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -76,9 +76,7 @@ Altair:
       current_epoch_participation:
         $ref: './epoch_participation.yaml#/Altair/EpochParticipation'
       justification_bits:
-        type: string
-        pattern: "^0x[a-fA-F0-9]+$"
-        example: "0x01"
+        $ref: "../primitive.yaml#/BitList"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/altair/sync_aggregate.yaml
+++ b/types/altair/sync_aggregate.yaml
@@ -4,9 +4,7 @@ Altair:
     description: "The [`SyncAggregate`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#syncaggregate) object from the CL Altair spec."
     properties:
       sync_committee_bits:
-        type: string
-        pattern: "^0x[a-fA-F0-9]+$"
-        example: "0x01"
+        $ref: "../primitive.yaml#/BitList"
         description: "Aggregation bits of sync"
       sync_committee_signature:
         $ref: '../primitive.yaml#/Signature'

--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -20,9 +20,7 @@ Attestation:
   description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestation) object from the CL spec."
   properties:
     aggregation_bits:
-      type: string
-      example: "0x01"
-      pattern: "^0x[a-fA-F0-9]+$"
+      $ref: "./primitive.yaml#/BitList"
       description: "Attester aggregation bits."
     signature:
       allOf:
@@ -36,8 +34,7 @@ PendingAttestation:
   description: "The [`PendingAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#pendingattestation) object from the CL spec."
   properties:
     aggregation_bits:
-      type: string
-      pattern: "^0x[a-fA-F0-9]+$"
+      $ref: "./primitive.yaml#/BitList"
       description: "Attester aggregation bits."
     data:
       $ref: '#/AttestationData'

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -76,9 +76,7 @@ Bellatrix:
       current_epoch_participation:
         $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
       justification_bits:
-        type: string
-        pattern: "^0x[a-fA-F0-9]+$"
-        example: "0x01"
+        $ref: "../primitive.yaml#/BitList"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -1,11 +1,13 @@
 Pubkey:
   type: string
+  format: hex
   pattern: "^0x[a-fA-F0-9]{96}$"
   description: "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._"
   example: "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
 
 ForkVersion:
   type: string
+  format: hex
   description: "a fork version number"
   example: "0x00000000"
   pattern: "^0x[a-fA-F0-9]{8}$"
@@ -45,11 +47,13 @@ ExecutionOptimistic:
 
 Root:
   type: string
+  format: hex
   example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
   pattern: "^0x[a-fA-F0-9]{64}$"
 
 Bytes32:
   type: string
+  format: hex
   example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
   pattern: "^0x[a-fA-F0-9]{64}$"
 
@@ -61,12 +65,20 @@ Graffiti:
 
 Hex:
   type: string
+  format: hex
   pattern: "^0x[a-fA-F0-9]{2,}$"
 
 Signature:
   type: string
+  format: hex
   pattern: "^0x[a-fA-F0-9]{192}$"
   example: "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+
+BitList:
+  type: string
+  format: hex
+  example: "0x01"
+  pattern: "^0x[a-fA-F0-9]+$"
 
 Uint8:
   type: string
@@ -76,23 +88,27 @@ Uint8:
 
 ExecutionAddress:
   type: string
+  format: hex
   description: "An address on the execution (Ethereum 1) network."
   example: "0xabcf8e0d4e9587369b2301d0790347320302cc09"
   pattern: "^0x[a-fA-F0-9]{40}$"
 
 Transaction:
   type: string
+  format: hex
   description: "A transaction on the execution (Ethereum 1) network."
   example: "0x02f878831469668303f51d843b9ac9f9843b9aca0082520894c93269b73096998db66be0441e836d873535cb9c8894a19041886f000080c001a031cc29234036afbf9a1fb9476b463367cb1f957ac0b919b69bbc798436e604aaa018c4e9c3914eb27aadd0b91e10b18655739fcf8c1fc398763a9f1beecb8ddc86"
   pattern: "^0x[a-fA-F0-9]{0,2147483648}$"
 
 ExtraData:
   type: string
+  format: hex
   description: "Extra data on the execution (Ethereum 1) network."
   example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
   pattern: "^0x[a-fA-F0-9]{0,64}$"
 
 LogsBloom:
   type: string
+  format: hex
   example: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
   pattern: "^0x[a-fA-F0-9]{512}$"

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -81,9 +81,7 @@ BeaconState:
         allOf:
           - $ref: './attestation.yaml#/PendingAttestation'
     justification_bits:
-      type: string
-      pattern: "^0x[a-fA-F0-9]+$"
-      example: "0x01"
+      $ref: "./primitive.yaml#/BitList"
       description: "Bit set for every recent justified epoch"
     previous_justified_checkpoint:
       $ref: "./misc.yaml#/Checkpoint"


### PR DESCRIPTION
From https://github.com/ethereum/beacon-APIs/pull/234#issuecomment-1232705540

Add consistently `format: hex` to all strings.

- [x] tested on local swagger render

```
swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml
cd deploy
python -m http.server 8080
```

![Screenshot from 2022-08-31 12-22-30](https://user-images.githubusercontent.com/35266934/187657717-b15b7948-f8e3-4ece-bc6b-11cb49a210db.png)

![Screenshot from 2022-08-31 12-22-44](https://user-images.githubusercontent.com/35266934/187657747-bfecd097-fa07-421b-a03b-9b7d8c1f21bd.png)

![Screenshot from 2022-08-31 12-22-54](https://user-images.githubusercontent.com/35266934/187657759-0a058856-03d0-49d5-89b6-1e4ac5814eb9.png)

![Screenshot from 2022-08-31 12-29-48](https://user-images.githubusercontent.com/35266934/187658480-d8a71fe9-0626-48ae-ac7a-8d7b0802dde3.png)

