### PR TITLE
Endpoint for fetching blinded blocks

### DIFF
--- a/apis/beacon/blocks/blinded_block.yaml
+++ b/apis/beacon/blocks/blinded_block.yaml
@@ -1,0 +1,61 @@
+get:
+  operationId: getBlindedBlock
+  summary: Get blinded block
+  description: |
+    Retrieves blinded block for given block ID.
+    Depending on `Accept` header it can be returned either as JSON or as bytes serialized by SSZ
+  tags:
+    - Beacon
+  parameters:
+    - name: block_id
+      in: path
+      required: true
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/BlockId'
+  responses:
+    "200":
+      description: "Successful response"
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+      content:
+        application/json:
+          schema:
+            title: GetBlindedBlockResponse
+            type: object
+            properties:
+              version:
+                type: string
+                enum: [phase0, altair, bellatrix]
+                example: "phase0"
+              execution_optimistic:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              data:
+                oneOf:
+                  - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"
+                  - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
+                  - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized block bytes. Use Accept header to choose this response type"
+    "400":
+      description: "The block ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid block ID: current"
+    "404":
+      description: "Block not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 404
+                  message: "Block not found"
+    "500":
+      $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -88,6 +88,8 @@ paths:
     $ref: "./apis/beacon/blocks/root.yaml"
   /eth/v1/beacon/blocks/{block_id}/attestations:
     $ref: "./apis/beacon/blocks/attestations.yaml"
+  /eth/v1/beacon/blinded_blocks/{block_id}:
+    $ref: "./apis/beacon/blocks/blinded_block.yaml"
 
   /eth/v1/beacon/pool/attestations:
     $ref: "./apis/beacon/pool/attestations.yaml"


### PR DESCRIPTION
This PR adds a new endpoint analogous to `/eth/v2/beacon/blocks/{block_id}` that serves _blinded_ blocks rather than full blocks. The new endpoint is `/eth/v1/beacon/blinded_blocks/{block_id}`.

We already have other endpoints for creating new blinded blocks and POSTing signed blinded blocks back to the BN, so this PR completes the trilogy.

There are several reasons why such an endpoint is useful and desirable:

- Most consensus clients do not store full blocks with execution payloads in their databases. Fetching a finalized blinded block can be done more quickly and efficiently than serving a full block which has had its payload pruned and would require a call to the EL to reconstruct.
- Blinded blocks contain a lot of useful information that isn't in block headers, including the execution block hash, execution block number, attestations, exits, etc. For many consensus-oriented tools blinded blocks are sufficient to conduct their analysis (this is true of my block fingerprinting tools, and @jclapis's Rocket Pool tools). Blinded blocks can also be useful for builders and execution-oriented tools which might want to know e.g. the `block_number` of the head block, without fetching all transactions.
