### PR TITLE
Endpoint for state RANDAO mix

### DIFF
--- a/apis/beacon/states/randao.yaml
+++ b/apis/beacon/states/randao.yaml
@@ -1,0 +1,63 @@
+get:
+  operationId: "getStateRandao"
+  summary: "Get the RANDAO mix for some epoch."
+  description: |
+    Fetch the RANDAO mix for a requested epoch from the state identified by `state_id`.
+
+    If an epoch is not specified then the RANDAO mix for the state's current epoch will be returned.
+  tags:
+    - Beacon
+  parameters:
+    - name: state_id
+      in: path
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+    - name: epoch
+      description: "Epoch to fetch the RANDAO mix for. Default: state's current epoch."
+      in: query
+      required: false
+      allowEmptyValue: false
+      schema:
+        allOf:
+          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+          - example: ""
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            title: GetStateRandaoResponse
+            type: object
+            properties:
+              execution_optimistic:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              data:
+                type: object
+                properties:
+                  randao:
+                    allOf:
+                      - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                      - description: RANDAO mix for requested epoch in state.
+    "400":
+      description: "Invalid state ID or epoch"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Epoch is out of range for the `randao_mixes` of the state"
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 404
+            message: "State not found"
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
+

--- a/apis/beacon/states/randao.yaml
+++ b/apis/beacon/states/randao.yaml
@@ -1,10 +1,14 @@
 get:
   operationId: "getStateRandao"
-  summary: "Get the RANDAO mix for some epoch."
+  summary: "Get the RANDAO mix for some epoch in a specified state."
   description: |
-    Fetch the RANDAO mix for a requested epoch from the state identified by `state_id`.
+    Fetch the RANDAO mix for the requested epoch from the state identified by `state_id`.
 
     If an epoch is not specified then the RANDAO mix for the state's current epoch will be returned.
+
+    By adjusting the `state_id` parameter you can query for any historic value of the RANDAO mix.
+    Ordinarily states from the same epoch will mutate the RANDAO mix for that epoch as blocks are
+    applied.
   tags:
     - Beacon
   parameters:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -74,6 +74,8 @@ paths:
     $ref: "./apis/beacon/states/committee.yaml"
   /eth/v1/beacon/states/{state_id}/sync_committees:
     $ref: "./apis/beacon/states/sync_committees.yaml"
+  /eth/v1/beacon/states/{state_id}/randao:
+    $ref: "./apis/beacon/states/randao.yaml"
   /eth/v1/beacon/headers:
     $ref: "./apis/beacon/blocks/headers.yaml"
   /eth/v1/beacon/headers/{block_id}:


### PR DESCRIPTION
Add an endpoint to fetch the RANDAO mix from a given state at some epoch.

The endpoint path is `/eth/v1/beacon/states/{state_id}/randao`.

With the merge the RANDAO mix has taken on increased significance, as it is embedded in execution payloads and available in the EVM.

Currently for tools that want to access the `prev_randao` from outside the beacon node for the purposes of payload construction or validation, they must load an entire beacon state using the debug endpoint. This is prohibitively slow for something that _should_ be fast with the right API.

With this API, they can immediately get access to the correct `prev_randao` value using `/eth/v1/beacon/states/head/randao` prior to block construction (or can use the `state_id` corresponding to the parent block).