### PR TITLE
Endpoint for EIP-4881 Deposit Contract Snapshot

### DIFF
--- a/apis/beacon/deposit_snapshot.yaml
+++ b/apis/beacon/deposit_snapshot.yaml
@@ -1,0 +1,34 @@
+  get:
+    operationId: getDepositSnapshot
+    summary: "Get Deposit Tree Snapshot"
+    description: |
+      Retrieve [EIP-4881](https://eips.ethereum.org/EIPS/eip-4881) Deposit Tree Snapshot.
+      Depending on `Accept` header it can be returned either as json or as bytes serialzed by SSZ
+    tags:
+      - Beacon
+    responses:
+      "200":
+        description: Success
+        content:
+          application/json:
+            schema:
+              type: object
+              title: GetDepositSnapshotResponse
+              properties:
+                data:
+                  $ref: '../../beacon-node-oapi.yaml#/components/schemas/DepositSnapshotResponse'
+          application/octet-stream:
+            schema:
+              description: "SSZ serialized block bytes. Use Accept header to choose this response type"
+      "404":
+        description: "No Finalized Snapshot Available"
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+                - example:
+                    code: 404
+                    message: "No Finalized Snapshot Available"
+      "500":
+        $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -89,6 +89,8 @@ paths:
   /eth/v1/beacon/blocks/{block_id}/attestations:
     $ref: "./apis/beacon/blocks/attestations.yaml"
 
+  /eth/v1/beacon/deposit_snapshot:
+    $ref: "./apis/beacon/deposit_snapshot.yaml"
   /eth/v1/beacon/pool/attestations:
     $ref: "./apis/beacon/pool/attestations.yaml"
   /eth/v1/beacon/pool/attester_slashings:
@@ -168,6 +170,8 @@ components:
       $ref: './types/state.yaml#/BeaconState'
     BeaconBlock:
       $ref: './types/block.yaml#/BeaconBlock'
+    DepositSnapshotResponse:
+      $ref: './types/api.yaml#/DepositSnapshotResponse'
     SignedBeaconBlock:
       $ref: './types/block.yaml#/SignedBeaconBlock'
     SignedBeaconBlockHeader:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -1,5 +1,24 @@
 # API specific types
 
+DepositSnapshotResponse:
+  type: object
+  properties:
+    finalized:
+      type: array
+      items:
+        allOf:
+          - $ref: './primitive.yaml#/Root'
+      minItems: 3
+      maxItems: 3
+    deposit_root:
+      $ref: './primitive.yaml#/Root'
+    deposit_count:
+      $ref: './primitive.yaml#/Uint64'
+    execution_block_hash:
+      $ref: './primitive.yaml#/Root'
+    execution_block_height:
+      $ref: './primitive.yaml#/Uint64'
+
 ValidatorResponse:
   type: object
   properties:


### PR DESCRIPTION
Adds the endpoint for downloading the [`EIP-4881`](https://eips.ethereum.org/EIPS/eip-4881#specification) Deposit Tree Snapshot during weak subjectivity sync.