### PR TITLE
Add capella types and endpoints.

### DIFF
--- a/apis/beacon/blocks/blinded_block.yaml
+++ b/apis/beacon/blocks/blinded_block.yaml
@@ -25,7 +25,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix]
+                enum: [phase0, altair, bellatrix, capella]
                 example: "phase0"
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -34,6 +34,7 @@ get:
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
+                  - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Capella.SignedBlindedBeaconBlock"
         application/octet-stream:
           schema:
             description: "SSZ serialized block bytes. Use Accept header to choose this response type"

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -31,6 +31,7 @@ post:
             - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock'
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
+            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Capella.SignedBlindedBeaconBlock"
       application/octet-stream:
         schema:
           description: "SSZ serialized block bytes. Use content type header to indicate that SSZ data is contained in the request body."

--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -25,7 +25,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix]
+                enum: [phase0, altair, bellatrix, capella]
                 example: "phase0"
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -34,6 +34,7 @@ get:
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
+                  - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Capella.SignedBeaconBlock"
         application/octet-stream:
           schema:
             

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -28,6 +28,7 @@ post:
             - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock'
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
+            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Capella.SignedBeaconBlock"
       application/octet-stream:
         schema:
           description: "SSZ serialized block bytes. Use content type header to indicate that SSZ data is contained in the request body."

--- a/apis/beacon/pool/bls_to_execution_changes.yaml
+++ b/apis/beacon/pool/bls_to_execution_changes.yaml
@@ -40,10 +40,9 @@ post:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Invalid BLS to execution change, it will never pass validation so it's rejected"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            example:
+              code: 400
+              message: "Invalid BLS to execution change, it will never pass validation so it's rejected"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/pool/bls_to_execution_changes.yaml
+++ b/apis/beacon/pool/bls_to_execution_changes.yaml
@@ -1,0 +1,49 @@
+get:
+  operationId: getPoolBLSToExecutionChanges
+  summary: Get SignedBLSToExecutionChange from operations pool
+  description: Retrieves BLS to execution changes known by the node but not necessarily incorporated into any block
+  tags:
+    - Beacon
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            title: GetPoolBLSToExecutionChangesResponse
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBLSToExecutionChange'
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
+
+post:
+  operationId: submitPoolBLSToExecutionChange
+  summary: Submit SignedBLSToExecutionChange object to node's pool
+  description: Submits SignedBLSToExecutionChange object to node's pool and if passes validation node MUST broadcast it to network.
+  tags:
+    - Beacon
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../../beacon-node-oapi.yaml#/components/schemas/SignedBLSToExecutionChange'
+  responses:
+    "200":
+      description: BLS to execution change is stored in node and broadcasted to network
+    "400":
+      description: "Invalid BLS to execution change"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "Invalid BLS to execution change, it will never pass validation so it's rejected"
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -25,7 +25,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [ phase0, altair, bellatrix ]
+                enum: [ phase0, altair, bellatrix, capella ]
                 example: "phase0"
               execution_optimistic:
                 $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -34,6 +34,7 @@ get:
                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconState'
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconState"
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BeaconState"
+                 - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Capella.BeaconState"
         application/octet-stream:
           schema:
             description: "SSZ serialized state bytes. Use Accept header to choose this response type"

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -26,6 +26,7 @@ get:
             - block
             - attestation
             - voluntary_exit
+            - bls_to_execution_change
             - finalized_checkpoint
             - chain_reorg
             - contribution_and_proof
@@ -58,6 +59,11 @@ get:
               value: |
                 event: voluntary_exit
                 data: {"message":{"epoch":"1", "validator_index":"1"}, "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}
+            bls_to_execution_change:
+              description: The node has received a BLS to execution change (from P2P or API)
+              value: |
+                event: bls_to_execution_change
+                data: {"message":{"validator_index":"1", "from_bls_pubkey":"0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95", "to_execution_address":"0x9be8d619c56699667c1fedcd15f6b14d8B067f72"}, "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}
             finalized_checkpoint:
               description: Finalized checkpoint has been updated
               value: |

--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -45,13 +45,14 @@ get:
             properties:
               version:
                 type: string
-                enum: [ phase0, altair, bellatrix ]
+                enum: [ phase0, altair, bellatrix, capella ]
                 example: "bellatrix"
               data:
                 oneOf:
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'
                   - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconBlock"
                   - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BlindedBeaconBlock"
+                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Capella.BlindedBeaconBlock"
         application/octet-stream:
           schema:
             description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is sent in header `Eth-Consensus-Version`."

--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -51,13 +51,14 @@ get:
             properties:
               version:
                 type: string
-                enum: [ phase0, altair, bellatrix ]
+                enum: [ phase0, altair, bellatrix, capella ]
                 example: "phase0"
               data:
                 oneOf:
                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconBlock"
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BeaconBlock"
+                 - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Capella.BeaconBlock"
         application/octet-stream:
           schema:
             description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is sent in header `Eth-Consensus-Version`."

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -101,6 +101,8 @@ paths:
     $ref: "./apis/beacon/pool/sync_committees.yaml"
   /eth/v1/beacon/pool/voluntary_exits:
     $ref: "./apis/beacon/pool/voluntary_exists.yaml"
+  /eth/v1/beacon/pool/bls_to_execution_changes:
+    $ref: "./apis/beacon/pool/bls_to_execution_changes.yaml"
 
   /eth/v2/debug/beacon/states/{state_id}:
     $ref: './apis/debug/state.v2.yaml'
@@ -188,6 +190,8 @@ components:
       $ref: './types/proposer_slashing.yaml#/ProposerSlashing'
     SignedVoluntaryExit:
       $ref: './types/voluntary_exit.yaml#/SignedVoluntaryExit'
+    SignedBLSToExecutionChange:
+      $ref: './types/bls_to_execution_change.yaml#/SignedBLSToExecutionChange'
     AttesterDuty:
       $ref: './types/validator.yaml#/AttesterDuty'
     ProposerDuty:
@@ -269,10 +273,20 @@ components:
     Bellatrix.SignedBlindedBeaconBlock:
       $ref: './types/bellatrix/block.yaml#/Bellatrix/SignedBlindedBeaconBlock'
     ConsensusVersion:
-      enum: [phase0, altair, bellatrix]
+      enum: [phase0, altair, bellatrix, capella]
       example: "phase0"
     SignedValidatorRegistration:
       $ref: './types/registration.yaml#/SignedValidatorRegistration'
+    Capella.BeaconState:
+      $ref: './types/capella/state.yaml#/Capella/BeaconState'
+    Capella.BeaconBlock:
+      $ref: './types/capella/block.yaml#/Capella/BeaconBlock'
+    Capella.SignedBeaconBlock:
+      $ref: './types/capella/block.yaml#/Capella/SignedBeaconBlock'
+    Capella.BlindedBeaconBlock:
+      $ref: './types/capella/block.yaml#/Capella/BlindedBeaconBlock'
+    Capella.SignedBlindedBeaconBlock:
+      $ref: './types/capella/block.yaml#/Capella/SignedBlindedBeaconBlock'
 
   parameters:
     StateId:

--- a/types/bls_to_execution_change.yaml
+++ b/types/bls_to_execution_change.yaml
@@ -1,0 +1,23 @@
+BLSToExecutionChange:
+  type: object
+  description: "The [`BLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#blstoexecutionchange) object from the CL spec."
+  properties:
+    validator_index:
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of the validator for which credentials will be changed."
+    from_bls_pubkey:
+      $ref: "./primitive.yaml#/Pubkey"
+      description: "Public key of existing credentials."
+    to_execution_address:
+      $ref: "./primitive.yaml#/ExecutionAddress"
+      description: "Execution address to which the credentials will be changed."
+
+SignedBLSToExecutionChange:
+  type: object
+  description: "The [`SignedBLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#signedblstoexecutionchange) object from the CL spec."
+  properties:
+    message:
+      $ref: "#/BLSToExecutionChange"
+    signature:
+      $ref: './primitive.yaml#/Signature'
+

--- a/types/capella/block.yaml
+++ b/types/capella/block.yaml
@@ -42,6 +42,10 @@ Capella:
         properties:
           execution_payload:
             $ref: './execution_payload.yaml#/Capella/ExecutionPayload'
+          bls_to_execution_changes:
+            type: array
+            items:
+              $ref: '../bls_to_execution_change.yaml#/SignedBLSToExecutionChange'
 
   BeaconBlock:
     description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/Capella/beacon-chain.md#beaconblock) object from the CL Capella spec."

--- a/types/capella/block.yaml
+++ b/types/capella/block.yaml
@@ -1,0 +1,89 @@
+Capella:
+  BeaconBlockBodyCommon:
+    # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
+    type: object
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec."
+    properties:
+      randao_reveal:
+        allOf:
+          - $ref: '../primitive.yaml#/Signature'
+          - description: "The RanDAO reveal value provided by the validator."
+      eth1_data:
+        $ref: '../eth1.yaml#/Eth1Data'
+      graffiti:
+        $ref: '../primitive.yaml#/Graffiti'
+      proposer_slashings:
+        type: array
+        items:
+          $ref: '../proposer_slashing.yaml#/ProposerSlashing'
+      attester_slashings:
+        type: array
+        items:
+          $ref: '../attester_slashing.yaml#/AttesterSlashing'
+      attestations:
+        type: array
+        items:
+          $ref: '../attestation.yaml#/Attestation'
+      deposits:
+        type: array
+        items:
+          $ref: '../deposit.yaml#/Deposit'
+      voluntary_exits:
+        type: array
+        items:
+          $ref: '../voluntary_exit.yaml#/SignedVoluntaryExit'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+
+  BeaconBlockBody:
+    allOf:
+      - $ref: '#/Capella/BeaconBlockBodyCommon'
+      - type: object
+        properties:
+          execution_payload:
+            $ref: './execution_payload.yaml#/Capella/ExecutionPayload'
+
+  BeaconBlock:
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/Capella/beacon-chain.md#beaconblock) object from the CL Capella spec."
+    allOf:
+      - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
+      - type: object
+        properties:
+          body:
+            $ref: '#/Capella/BeaconBlockBody'
+
+  SignedBeaconBlock:
+    type: object
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec."
+    properties:
+      message:
+        $ref: "#/Capella/BeaconBlock"
+      signature:
+        $ref: "../primitive.yaml#/Signature"
+
+  BlindedBeaconBlockBody:
+    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec, which contains a transactions root rather than a full transactions list."
+    allOf:
+      - $ref: '#/Capella/BeaconBlockBodyCommon'
+      - type: object
+        properties:
+          execution_payload_header:
+            $ref: './execution_payload.yaml#/Capella/ExecutionPayloadHeader'
+
+  BlindedBeaconBlock:
+    description: "A variant of the the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblock) object from the CL Capella spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
+    allOf:
+      - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
+      - type: object
+        properties:
+          body:
+            $ref: '#/Capella/BlindedBeaconBlockBody'
+
+  SignedBlindedBeaconBlock:
+    type: object
+    description: "A variant of the the the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    properties:
+      message:
+        $ref: "#/Capella/BlindedBeaconBlock"
+      signature:
+        $ref: "../primitive.yaml#/Signature"

--- a/types/capella/execution_payload.yaml
+++ b/types/capella/execution_payload.yaml
@@ -1,0 +1,54 @@
+Capella:
+  ExecutionPayloadCommon:
+    # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
+    type: object
+    description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#executionpayload) object from the CL Capella spec."
+    properties:
+      parent_hash:
+        $ref: '../primitive.yaml#/Root'
+      fee_recipient:
+        $ref: '../primitive.yaml#/ExecutionAddress'
+      state_root:
+        $ref: '../primitive.yaml#/Root'
+      receipts_root:
+        $ref: '../primitive.yaml#/Root'
+      logs_bloom:
+        $ref: '../primitive.yaml#/LogsBloom'
+      prev_randao:
+        $ref: '../primitive.yaml#/Bytes32'
+      block_number:
+        $ref: '../primitive.yaml#/Uint64'
+      gas_limit:
+        $ref: '../primitive.yaml#/Uint64'
+      gas_used:
+        $ref: '../primitive.yaml#/Uint64'
+      timestamp:
+        $ref: '../primitive.yaml#/Uint64'
+      extra_data:
+        $ref: '../primitive.yaml#/ExtraData'
+      base_fee_per_gas:
+        $ref: '../primitive.yaml#/Uint256'
+      block_hash:
+        $ref: '../primitive.yaml#/Root'
+
+
+  ExecutionPayload:
+    allOf:
+      - $ref: '#/Capella/ExecutionPayloadCommon'
+      - type: object
+        properties:
+          transactions:
+            $ref: './transactions.yaml#/Capella/Transactions'
+          withdrawals:
+            $ref: './withdrawals.yaml#/Capella/Withdrawals'
+
+  ExecutionPayloadHeader:
+    description: "The [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#executionpayloadheader) object from the CL Capella spec."
+    allOf:
+      - $ref: '#/Capella/ExecutionPayloadCommon'
+      - type: object
+        properties:
+          transactions_root:
+            $ref: '../primitive.yaml#/Root'
+          withdrawals_root:
+            $ref: '../primitive.yaml#/Root'

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -1,0 +1,109 @@
+Capella:
+  BeaconState:
+    type: object
+    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconstate) object from the Eth2.0 Capella spec."
+    properties:
+      genesis_time:
+        $ref: "../primitive.yaml#/Uint64"
+      genesis_validators_root:
+        $ref: "../primitive.yaml#/Root"
+      slot:
+        $ref: "../primitive.yaml#/Uint64"
+      fork:
+        $ref: "../misc.yaml#/Fork"
+      latest_block_header:
+        $ref: "../block.yaml#/BeaconBlockHeader"
+      block_roots:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        minItems: 8192
+        maxItems: 8192
+      state_roots:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        minItems: 8192
+        maxItems: 8192
+      historical_roots:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Root'
+        maxItems: 16777216
+      eth1_data:
+        $ref: "../eth1.yaml#/Eth1Data"
+      eth1_data_votes:
+        type: array
+        items:
+          allOf:
+            - $ref: '../eth1.yaml#/Eth1Data'
+        maxItems: 1024
+      eth1_deposit_index:
+        $ref: "../primitive.yaml#/Uint64"
+      validators:
+        type: array
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: '../validator.yaml#/Validator'
+      balances:
+        type: array
+        description: "Validator balances in gwei"
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Uint64'
+      randao_mixes:
+        type: array
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Bytes32'
+        minItems: 65536
+        maxItems: 65536
+      slashings:
+        type: array
+        description: "Per-epoch sums of slashed effective balances"
+        items:
+          allOf:
+            - $ref: '../primitive.yaml#/Uint64'
+        minItems: 8192
+        maxItems: 8192
+      previous_epoch_participation:
+        $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
+      current_epoch_participation:
+        $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
+      justification_bits:
+        $ref: "../primitive.yaml#/BitList"
+        description: "Bit set for every recent justified epoch"
+      previous_justified_checkpoint:
+        $ref: "../misc.yaml#/Checkpoint"
+      current_justified_checkpoint:
+        $ref: "../misc.yaml#/Checkpoint"
+      finalized_checkpoint:
+        $ref: "../misc.yaml#/Checkpoint"
+      inactivity_scores:
+        description: "Per-validator inactivity scores. New in Altair"
+        type: array
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: "../primitive.yaml#/Uint64"
+      current_sync_committee:
+        $ref: "../altair/sync_committee.yaml#/Altair/SyncCommittee"
+      next_sync_committee:
+        $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
+      latest_execution_payload_header:
+        $ref: './execution_payload.yaml#/Capella/ExecutionPayloadHeader'
+      withdrawal_queue:
+        type: array
+        maxItems: 1099511627776
+        items:
+          allOf:
+            - $ref: '../withdrawal.yaml#/Withdrawal'
+      next_withdrawal_index:
+        $ref: "../primitive.yaml#/Uint64"
+      next_partial_withdrawal_validator_index:
+        $ref: "../primitive.yaml#/Uint64"

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -16,30 +16,26 @@ Capella:
       block_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         minItems: 8192
         maxItems: 8192
       state_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         minItems: 8192
         maxItems: 8192
       historical_roots:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
         maxItems: 16777216
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
         type: array
         items:
-          allOf:
-            - $ref: '../eth1.yaml#/Eth1Data'
+          $ref: '../eth1.yaml#/Eth1Data'
         maxItems: 1024
       eth1_deposit_index:
         $ref: "../primitive.yaml#/Uint64"
@@ -47,28 +43,24 @@ Capella:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../validator.yaml#/Validator'
+          $ref: '../validator.yaml#/Validator'
       balances:
         type: array
         description: "Validator balances in gwei"
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Bytes32'
+          $ref: '../primitive.yaml#/Bytes32'
         minItems: 65536
         maxItems: 65536
       slashings:
         type: array
         description: "Per-epoch sums of slashed effective balances"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
         minItems: 8192
         maxItems: 8192
       previous_epoch_participation:
@@ -89,8 +81,7 @@ Capella:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: "../primitive.yaml#/Uint64"
+          $ref: "../primitive.yaml#/Uint64"
       current_sync_committee:
         $ref: "../altair/sync_committee.yaml#/Altair/SyncCommittee"
       next_sync_committee:
@@ -101,8 +92,7 @@ Capella:
         type: array
         maxItems: 1099511627776
         items:
-          allOf:
-            - $ref: '../withdrawal.yaml#/Withdrawal'
+          $ref: '../withdrawal.yaml#/Withdrawal'
       next_withdrawal_index:
         $ref: "../primitive.yaml#/Uint64"
       next_partial_withdrawal_validator_index:

--- a/types/capella/transactions.yaml
+++ b/types/capella/transactions.yaml
@@ -2,6 +2,5 @@ Capella:
   Transactions:
       type: array
       items:
-        allOf:
-          - $ref: '../primitive.yaml#/Transaction'
+        $ref: '../primitive.yaml#/Transaction'
       maxItems: 1048576

--- a/types/capella/transactions.yaml
+++ b/types/capella/transactions.yaml
@@ -1,0 +1,7 @@
+Capella:
+  Transactions:
+      type: array
+      items:
+        allOf:
+          - $ref: '../primitive.yaml#/Transaction'
+      maxItems: 1048576

--- a/types/capella/withdrawals.yaml
+++ b/types/capella/withdrawals.yaml
@@ -1,0 +1,7 @@
+Capella:
+  Withdrawals:
+      type: array
+      items:
+        allOf:
+          - $ref: '../withdrawal.yaml#/Withdrawal'
+      maxItems: 16

--- a/types/capella/withdrawals.yaml
+++ b/types/capella/withdrawals.yaml
@@ -2,6 +2,5 @@ Capella:
   Withdrawals:
       type: array
       items:
-        allOf:
-          - $ref: '../withdrawal.yaml#/Withdrawal'
+        $ref: '../withdrawal.yaml#/Withdrawal'
       maxItems: 16

--- a/types/withdrawal.yaml
+++ b/types/withdrawal.yaml
@@ -4,6 +4,9 @@ Withdrawal:
     index:
       $ref: './primitive.yaml#/Uint64'
       description: "The index of the withdrawal."
+    validator_index:
+      $ref: './primitive.yaml#/Uint64'
+      description: "The index of the withdrawing validator."
     address:
       $ref: './primitive.yaml#/ExecutionAddress'
       description: "The address to which the withdrawal is credited."

--- a/types/withdrawal.yaml
+++ b/types/withdrawal.yaml
@@ -1,0 +1,12 @@
+Withdrawal:
+  type: object
+  properties:
+    index:
+      $ref: './primitive.yaml#/Uint64'
+      description: "The index of the withdrawal."
+    address:
+      $ref: './primitive.yaml#/ExecutionAddress'
+      description: "The address to which the withdrawal is credited."
+    amount:
+      $ref: "./primitive.yaml#/Gwei"
+      description: "The value withdrawn (gwei)."


### PR DESCRIPTION
Update existing types to capella spec, use them where appropriate (blocks, execution payloads).

Add `BLSToExecutionChange` type and related types and endpoints.

Spec references point to master at current, will change once a tagged capella release is made.