### PR TITLE
Add `skip_randao_verification` for blinded blocks

### DIFF
--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -31,6 +31,15 @@ get:
       description: "Arbitrary data validator wants to include in block."
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Graffiti'
+    - name: skip_randao_verification
+      in: query
+      required: false
+      description: |
+        Skip verification of the `randao_reveal` value. If this flag is set then the
+        `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter
+        is a flag and does not take a value.
+      schema: {}
+      allowEmptyValue: true
   responses:
     "200":
       description: Success response


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/beacon-APIs/pull/222.

The endpoint for producing blinded blocks needs the `skip_randao_verification` parameter for the same reasons as the regular endpoint (see #222). It was an oversight on my part to not include it from the beginning.

The parameter is already implemented in Lighthouse (because code is shared with the non-blinded backend), and it seems that in Nimbus the blinded endpoint is not yet supported. Other clients don't verify RANDAO reveals during block production (yet) and do not need to implement the flag or can implement it as a no-op.