### PR TITLE
Give liveness epoch same "shape" as attester duties

### DIFF
--- a/apis/validator/liveness.yaml
+++ b/apis/validator/liveness.yaml
@@ -18,7 +18,7 @@ post:
       in: path
       required: true
       schema:
-        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+        $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
   requestBody:
     description: "An array of the validator indices for which to detect liveness."
     required: true
@@ -28,7 +28,7 @@ post:
           title: PostLivenessRequestBody
           type: array
           items:
-            $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+            $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
             minItems: 1
   responses:
     "200":

--- a/apis/validator/liveness.yaml
+++ b/apis/validator/liveness.yaml
@@ -12,6 +12,13 @@ post:
     and based upon a subjective view of the network. A beacon node that was recently
     started or suffered a network partition may indicate that a validator is not live
     when it actually is."
+  parameters:
+    - name: epoch
+      description: "The epoch for which liveness is being queried"
+      in: path
+      required: true
+      schema:
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
   requestBody:
     description: "An array of the validator indices for which to detect liveness."
     required: true
@@ -19,15 +26,10 @@ post:
       application/json:
         schema:
           title: PostLivenessRequestBody
-          type: object
-          properties:
-            epoch:
-              $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
-            indices:
-              type: array
-              items:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                minItems: 1
+          type: array
+          items:
+            $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+            minItems: 1
   responses:
     "200":
       description: Success response

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -168,7 +168,7 @@ paths:
     $ref: "./apis/validator/prepare_beacon_proposer.yaml"
   /eth/v1/validator/register_validator:
     $ref: "./apis/validator/register_validator.yaml"
-  /eth/v1/validator/liveness:
+  /eth/v1/validator/liveness/{epoch}:
     $ref: "./apis/validator/liveness.yaml"
 
   /eth/v1/events:


### PR DESCRIPTION
https://github.com/ethereum/beacon-APIs/pull/131 introduced a new liveness endpoint - the request is similar to attester duties in that we query a list of validators for data pertaining to a particular epoch - as such, it seems reasonable to keep the two requests similar in terms of their URL/postdata structure.