### PR TITLE
Add `finalized` flag to chain data requests

### DIFF
--- a/apis/beacon/blocks/attestations.yaml
+++ b/apis/beacon/blocks/attestations.yaml
@@ -9,7 +9,7 @@ get:
       in: path
       required: true
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/BlockId'
-  
+
   responses:
     "200":
       description: Success
@@ -21,6 +21,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: array
                 items:

--- a/apis/beacon/blocks/blinded_block.yaml
+++ b/apis/beacon/blocks/blinded_block.yaml
@@ -29,6 +29,8 @@ get:
                 example: "phase0"
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 oneOf:
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"

--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -29,6 +29,8 @@ get:
                 example: "phase0"
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 oneOf:
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"
@@ -36,7 +38,7 @@ get:
                   - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
         application/octet-stream:
           schema:
-            
+
             description: "SSZ serialized block bytes. Use Accept header to choose this response type"
     "400":
       description: "The block ID supplied could not be parsed"

--- a/apis/beacon/blocks/header.yaml
+++ b/apis/beacon/blocks/header.yaml
@@ -20,6 +20,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
                 properties:

--- a/apis/beacon/blocks/headers.yaml
+++ b/apis/beacon/blocks/headers.yaml
@@ -19,7 +19,7 @@ get:
         allOf:
           - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"
           - example: ""
-  
+
   responses:
     "200":
       description: Success
@@ -31,6 +31,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: array
                 items:

--- a/apis/beacon/blocks/root.yaml
+++ b/apis/beacon/blocks/root.yaml
@@ -26,6 +26,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
                 properties:

--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -44,6 +44,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: array
                 items:

--- a/apis/beacon/states/finality_checkpoints.yaml
+++ b/apis/beacon/states/finality_checkpoints.yaml
@@ -21,6 +21,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
                 properties:

--- a/apis/beacon/states/fork.yaml
+++ b/apis/beacon/states/fork.yaml
@@ -20,6 +20,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Fork'
 

--- a/apis/beacon/states/randao.yaml
+++ b/apis/beacon/states/randao.yaml
@@ -35,6 +35,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
                 properties:

--- a/apis/beacon/states/root.yaml
+++ b/apis/beacon/states/root.yaml
@@ -19,6 +19,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
                 properties:

--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -28,6 +28,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommittee'
 

--- a/apis/beacon/states/validator.yaml
+++ b/apis/beacon/states/validator.yaml
@@ -27,6 +27,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorResponse'
     "400":

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -37,6 +37,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: array
                 items:

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -48,6 +48,8 @@ get:
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: array
                 items:

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -29,6 +29,8 @@ get:
                 example: "phase0"
               execution_optimistic:
                 $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 oneOf:
                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconState'

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -30,7 +30,7 @@ get:
               execution_optimistic:
                 $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
               finalized:
-                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
+                $ref: "../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 oneOf:
                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconState'

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -18,7 +18,7 @@ post:
 
       - event.block otherwise
 
-    
+
     The dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)`
     or the genesis block root in the case of underflow."
   parameters:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -237,6 +237,8 @@ components:
       $ref: './types/primitive.yaml#/DependentRoot'
     ExecutionOptimistic:
       $ref: './types/primitive.yaml#/ExecutionOptimistic'
+    Finalized:
+      $ref: './types/primitive.yaml#/Finalized'
     Root:
       $ref: './types/primitive.yaml#/Root'
     Hex:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -45,6 +45,12 @@ ExecutionOptimistic:
     - example: false
     - description: "True if the response references an unverified execution payload. Optimistic information may be invalidated at a later time. If the field is not present, assume the False value."
 
+Finalized:
+  allOf:
+    - type: boolean
+    - example: false
+    - description: "True if the response references the finalized history of the chain, as determined by fork choice. If the field is not present, additional calls are necessary to compare the epoch of the requested information with the finalized checkpoint."
+
 Root:
   type: string
   format: hex


### PR DESCRIPTION
Whether or not a request pertains to the finalized section of the chain (per the view of the client fork choice) is somewhat cumbersome to discover.

This PR adds a boolean that allows clients to distinguish a response that has been finalized and thus is unlikely to change from one that may still change over time (specially when using slot-based requests).

A flag like this can also be used for the purpose of verifying that a checkpoint root indeed is part of chain history and is likely to remain as such, as discussed in
https://github.com/ethereum/beacon-APIs/pull/226