### PR TITLE
Remove maxItems from lists in debug/states

### DIFF
--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -32,7 +32,6 @@ Altair:
         items:
           allOf:
             - $ref: '../primitive.yaml#/Root'
-        maxItems: 16777216
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
@@ -45,14 +44,12 @@ Altair:
         $ref: "../primitive.yaml#/Uint64"
       validators:
         type: array
-        maxItems: 1099511627776
         items:
           allOf:
             - $ref: '../validator.yaml#/Validator'
       balances:
         type: array
         description: "Validator balances in gwei"
-        maxItems: 1099511627776
         items:
           allOf:
             - $ref: '../primitive.yaml#/Uint64'
@@ -87,7 +84,6 @@ Altair:
       inactivity_scores:
         description: "Per-validator inactivity scores. New in Altair"
         type: array
-        maxItems: 1099511627776
         items:
           allOf:
             - $ref: "../primitive.yaml#/Uint64"

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -15,59 +15,48 @@ Altair:
         $ref: "../block.yaml#/BeaconBlockHeader"
       block_roots:
         type: array
+        description: "Fixed length of 8192 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
-        minItems: 8192
-        maxItems: 8192
+          $ref: '../primitive.yaml#/Root'
       state_roots:
         type: array
+        description: "Fixed length of 8192 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
-        minItems: 8192
-        maxItems: 8192
+          $ref: '../primitive.yaml#/Root'
       historical_roots:
         type: array
+        description: "Variable length list, maximum 16777216 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
         type: array
+        description: "Fixed length of 1024 items"
         items:
-          allOf:
-            - $ref: '../eth1.yaml#/Eth1Data'
-        maxItems: 1024
+          $ref: '../eth1.yaml#/Eth1Data'
       eth1_deposit_index:
         $ref: "../primitive.yaml#/Uint64"
       validators:
         type: array
+        description: "Variable length list, maximum 1099511627776 items"
         items:
-          allOf:
-            - $ref: '../validator.yaml#/Validator'
+          $ref: '../validator.yaml#/Validator'
       balances:
         type: array
-        description: "Validator balances in gwei"
+        description: "Validator balances in gwei. Variable length list, maximum 1099511627776 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
         type: array
+        description: "Fixed length of 65536 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Bytes32'
-        minItems: 65536
-        maxItems: 65536
+          $ref: '../primitive.yaml#/Bytes32'
       slashings:
         type: array
-        description: "Per-epoch sums of slashed effective balances"
+        description: "Per-epoch sums of slashed effective balances. Fixed length of 8192 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
-        minItems: 8192
-        maxItems: 8192
+          $ref: '../primitive.yaml#/Uint64'
       previous_epoch_participation:
         $ref: './epoch_participation.yaml#/Altair/EpochParticipation'
       current_epoch_participation:
@@ -82,7 +71,7 @@ Altair:
       finalized_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"
       inactivity_scores:
-        description: "Per-validator inactivity scores. New in Altair"
+        description: "Per-validator inactivity scores. New in Altair. Variable length list, maximum 1099511627776 items"
         type: array
         items:
           allOf:

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -15,59 +15,49 @@ Bellatrix:
         $ref: "../block.yaml#/BeaconBlockHeader"
       block_roots:
         type: array
+        description: "Fixed length of 8192 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
-        minItems: 8192
-        maxItems: 8192
+          $ref: '../primitive.yaml#/Root'
       state_roots:
         type: array
+        description: "Fixed length of 8192 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
-        minItems: 8192
-        maxItems: 8192
+          $ref: '../primitive.yaml#/Root'
       historical_roots:
         type: array
+        description: "Variable length list, maximum 16777216 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Root'
+          $ref: '../primitive.yaml#/Root'
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
         type: array
+        description: "Fixed length of 1024 items"
         items:
-          allOf:
-            - $ref: '../eth1.yaml#/Eth1Data'
+          $ref: '../eth1.yaml#/Eth1Data'
         maxItems: 1024
       eth1_deposit_index:
         $ref: "../primitive.yaml#/Uint64"
       validators:
         type: array
+        description: "Variable length list, maximum 1099511627776 items"
         items:
-          allOf:
-            - $ref: '../validator.yaml#/Validator'
+          $ref: '../validator.yaml#/Validator'
       balances:
         type: array
-        description: "Validator balances in gwei"
+        description: "Validator balances in gwei. Variable length list, maximum 1099511627776 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
+          $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
         type: array
+        description: "Fixed length of 65536 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Bytes32'
-        minItems: 65536
-        maxItems: 65536
+          $ref: '../primitive.yaml#/Bytes32'
       slashings:
         type: array
-        description: "Per-epoch sums of slashed effective balances"
+        description: "Per-epoch sums of slashed effective balances. Fixed length of 8192 items"
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Uint64'
-        minItems: 8192
-        maxItems: 8192
+          $ref: '../primitive.yaml#/Uint64'
       previous_epoch_participation:
         $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
       current_epoch_participation:
@@ -82,11 +72,10 @@ Bellatrix:
       finalized_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"
       inactivity_scores:
-        description: "Per-validator inactivity scores. New in Altair"
+        description: "Per-validator inactivity scores. Introduced in Altair. Variable length list, maximum 1099511627776 items"
         type: array
         items:
-          allOf:
-            - $ref: "../primitive.yaml#/Uint64"
+          $ref: "../primitive.yaml#/Uint64"
       current_sync_committee:
         $ref: "../altair/sync_committee.yaml#/Altair/SyncCommittee"
       next_sync_committee:

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -32,7 +32,6 @@ Bellatrix:
         items:
           allOf:
             - $ref: '../primitive.yaml#/Root'
-        maxItems: 16777216
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
@@ -45,14 +44,12 @@ Bellatrix:
         $ref: "../primitive.yaml#/Uint64"
       validators:
         type: array
-        maxItems: 1099511627776
         items:
           allOf:
             - $ref: '../validator.yaml#/Validator'
       balances:
         type: array
         description: "Validator balances in gwei"
-        maxItems: 1099511627776
         items:
           allOf:
             - $ref: '../primitive.yaml#/Uint64'
@@ -87,7 +84,6 @@ Bellatrix:
       inactivity_scores:
         description: "Per-validator inactivity scores. New in Altair"
         type: array
-        maxItems: 1099511627776
         items:
           allOf:
             - $ref: "../primitive.yaml#/Uint64"

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -15,24 +15,24 @@ Capella:
         $ref: "../block.yaml#/BeaconBlockHeader"
       block_roots:
         type: array
+        description: "Fixed length of 8192 items"
         items:
           $ref: '../primitive.yaml#/Root'
-        minItems: 8192
-        maxItems: 8192
       state_roots:
         type: array
+        description: "Fixed length of 8192 items"
         items:
           $ref: '../primitive.yaml#/Root'
-        minItems: 8192
-        maxItems: 8192
       historical_roots:
         type: array
+        description: "Variable length list, maximum 16777216 items"
         items:
           $ref: '../primitive.yaml#/Root'
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
         type: array
+        description: "Fixed length of 1024 items"
         items:
           $ref: '../eth1.yaml#/Eth1Data'
         maxItems: 1024
@@ -40,26 +40,24 @@ Capella:
         $ref: "../primitive.yaml#/Uint64"
       validators:
         type: array
+        description: "Variable length list, maximum 1099511627776 items"
         items:
           $ref: '../validator.yaml#/Validator'
       balances:
         type: array
-        description: "Validator balances in gwei"
+        description: "Validator balances in gwei. Variable length list, maximum 1099511627776 items"
         items:
           $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
         type: array
+        description: "Fixed length of 65536 items"
         items:
           $ref: '../primitive.yaml#/Bytes32'
-        minItems: 65536
-        maxItems: 65536
       slashings:
         type: array
-        description: "Per-epoch sums of slashed effective balances"
+        description: "Per-epoch sums of slashed effective balances. Fixed length of 8192 items"
         items:
           $ref: '../primitive.yaml#/Uint64'
-        minItems: 8192
-        maxItems: 8192
       previous_epoch_participation:
         $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
       current_epoch_participation:
@@ -74,7 +72,7 @@ Capella:
       finalized_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"
       inactivity_scores:
-        description: "Per-validator inactivity scores. New in Altair"
+        description: "Per-validator inactivity scores. Introduced in Altair. Variable length list, maximum 1099511627776 items"
         type: array
         items:
           $ref: "../primitive.yaml#/Uint64"
@@ -86,6 +84,7 @@ Capella:
         $ref: './execution_payload.yaml#/Capella/ExecutionPayloadHeader'
       withdrawal_queue:
         type: array
+        description: "Withdrawals enqueued in state. Variable length list, maximum  1099511627776 items"
         items:
           $ref: '../withdrawal.yaml#/Withdrawal'
       next_withdrawal_index:

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -29,7 +29,6 @@ Capella:
         type: array
         items:
           $ref: '../primitive.yaml#/Root'
-        maxItems: 16777216
       eth1_data:
         $ref: "../eth1.yaml#/Eth1Data"
       eth1_data_votes:
@@ -41,13 +40,11 @@ Capella:
         $ref: "../primitive.yaml#/Uint64"
       validators:
         type: array
-        maxItems: 1099511627776
         items:
           $ref: '../validator.yaml#/Validator'
       balances:
         type: array
         description: "Validator balances in gwei"
-        maxItems: 1099511627776
         items:
           $ref: '../primitive.yaml#/Uint64'
       randao_mixes:
@@ -79,7 +76,6 @@ Capella:
       inactivity_scores:
         description: "Per-validator inactivity scores. New in Altair"
         type: array
-        maxItems: 1099511627776
         items:
           $ref: "../primitive.yaml#/Uint64"
       current_sync_committee:
@@ -90,7 +86,6 @@ Capella:
         $ref: './execution_payload.yaml#/Capella/ExecutionPayloadHeader'
       withdrawal_queue:
         type: array
-        maxItems: 1099511627776
         items:
           $ref: '../withdrawal.yaml#/Withdrawal'
       next_withdrawal_index:

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -57,8 +57,8 @@ BeaconState:
       items:
         allOf:
           - $ref: './primitive.yaml#/Bytes32'
-        minItems: 65536
-        maxItems: 65536
+      minItems: 65536
+      maxItems: 65536
     slashings:
       type: array
       description: "Per-epoch sums of slashed effective balances"

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -52,6 +52,13 @@ BeaconState:
       items:
         allOf:
           - $ref: './primitive.yaml#/Uint64'
+    randao_mixes:
+      type: array
+      items:
+        allOf:
+          - $ref: './primitive.yaml#/Bytes32'
+        minItems: 65536
+        maxItems: 65536
     slashings:
       type: array
       description: "Per-epoch sums of slashed effective balances"

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -31,7 +31,6 @@ BeaconState:
       items:
         allOf:
           - $ref: './primitive.yaml#/Root'
-      maxItems: 16777216
     eth1_data:
       $ref: "./eth1.yaml#/Eth1Data"
     eth1_data_votes:
@@ -44,24 +43,15 @@ BeaconState:
       $ref: "./primitive.yaml#/Uint64"
     validators:
       type: array
-      maxItems: 1099511627776
       items:
         allOf:
           - $ref: './validator.yaml#/Validator'
     balances:
       type: array
       description: "Validator balances in gwei"
-      maxItems: 1099511627776
       items:
         allOf:
           - $ref: './primitive.yaml#/Uint64'
-    randao_mixes:
-      type: array
-      items:
-        allOf:
-          - $ref: './primitive.yaml#/Bytes32'
-      minItems: 65536
-      maxItems: 65536
     slashings:
       type: array
       description: "Per-epoch sums of slashed effective balances"

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -14,69 +14,56 @@ BeaconState:
       $ref: "./block.yaml#/BeaconBlockHeader"
     block_roots:
       type: array
+      description: "Fixed length of 8192 items"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
-      minItems: 8192
-      maxItems: 8192
+        $ref: './primitive.yaml#/Root'
     state_roots:
       type: array
+      description: "Fixed length of 8192 items"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
-      minItems: 8192
-      maxItems: 8192
+        $ref: './primitive.yaml#/Root'
     historical_roots:
       type: array
+      description: "Variable length list, maximum 16777216 items"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
     eth1_data:
       $ref: "./eth1.yaml#/Eth1Data"
     eth1_data_votes:
       type: array
+      description: "Fixed length of 1024 items"
       items:
-        allOf:
-          - $ref: './eth1.yaml#/Eth1Data'
-      maxItems: 1024
+        $ref: './eth1.yaml#/Eth1Data'
     eth1_deposit_index:
       $ref: "./primitive.yaml#/Uint64"
     validators:
       type: array
+      description: "Variable length list, maximum 1099511627776 items"
       items:
-        allOf:
-          - $ref: './validator.yaml#/Validator'
+        $ref: './validator.yaml#/Validator'
     balances:
       type: array
-      description: "Validator balances in gwei"
+      description: "Validator balances in gwei. Variable length list, maximum 1099511627776 items"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Uint64'
+        $ref: './primitive.yaml#/Uint64'
     randao_mixes:
       type: array
+      description: "Fixed length of 65536 items"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Bytes32'
-      minItems: 65536
-      maxItems: 65536
+        $ref: './primitive.yaml#/Bytes32'
     slashings:
       type: array
-      description: "Per-epoch sums of slashed effective balances"
+      description: "Per-epoch sums of slashed effective balances. Fixed length of 8192 items"
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Uint64'
-      minItems: 8192
-      maxItems: 8192
+        $ref: './primitive.yaml#/Uint64'
     previous_epoch_attestations:
       type: array
       items:
-        allOf:
-          - $ref: './attestation.yaml#/PendingAttestation'
+        $ref: './attestation.yaml#/PendingAttestation'
     current_epoch_attestations:
       type: array
       items:
-        allOf:
-          - $ref: './attestation.yaml#/PendingAttestation'
+        $ref: './attestation.yaml#/PendingAttestation'
     justification_bits:
       $ref: "./primitive.yaml#/BitList"
       description: "Bit set for every recent justified epoch"


### PR DESCRIPTION
When rendering example data, huge lists will cause the page to stop responding.

This is particularly evident in BeaconState, where our limits are huge, and we only specify a maximum.

The limits are functionally huge so I removed them, as setting minItems didn't seem as effective in keeping the swagger page alive...

fixes #257 