### PR TITLE
WIP: Add endpoints for ```per validator rewards```

### DIFF
--- a/apis/beacon/blocks/attestations_rewards.yaml
+++ b/apis/beacon/blocks/attestations_rewards.yaml
@@ -1,0 +1,7 @@
+get:
+  operationId: WIP
+  summary: WIP
+  description: WIP
+  tags:
+    - Beacon
+    

--- a/apis/beacon/blocks/rewards.yaml
+++ b/apis/beacon/blocks/rewards.yaml
@@ -1,0 +1,7 @@
+get:
+  operationId: WIP
+  summary: WIP
+  description: WIP
+  tags:
+    - Beacon
+    

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -90,8 +90,12 @@ paths:
     $ref: "./apis/beacon/blocks/root.yaml"
   /eth/v1/beacon/blocks/{block_id}/attestations:
     $ref: "./apis/beacon/blocks/attestations.yaml"
+  /eth/v1/beacon/attestations/{epoch}/rewards:
+    $ref: "./apis/beacon/blocks/attestations_rewards.yaml"
   /eth/v1/beacon/blinded_blocks/{block_id}:
     $ref: "./apis/beacon/blocks/blinded_block.yaml"
+  /eth/v1/beacon/blocks/{slot}/rewards:
+    $ref: "./apis/beacon/blocks/rewards.yaml"
   /eth/v1/beacon/light_client/bootstrap/{block_root}:
     $ref: "./apis/beacon/light_client/bootstrap.yaml"
   /eth/v1/beacon/light_client/updates:


### PR DESCRIPTION
# WIP

Issue: https://github.com/sigp/lighthouse/issues/3661

Currently, there is no way to get block rewards paid on the consensus side. 

```/eth/v1/beacon/blocks/{slot}/rewards```

```json
{
  "proposer_index": "123",
  "total": "5000",
  "attestations": "3000",
  "sync_aggregate": "2000",
  "proposer_slashings": "0",
  "attester_slashings": "0",
}
```
---

```/eth/v1/beacon/attestations/{epoch}/rewards```

```json
{
  "0": {
     "head": "0",
     "target": "-2000",
     "source": "2000",
  },
  "1": {
    "head": "2000",
    "target": "4000",
    "source": "4000",
  },
 ..
}
```
