### PR TITLE
Change forkchoice checkpoints to epochs

### DIFF
--- a/apis/debug/fork_choice.yaml
+++ b/apis/debug/fork_choice.yaml
@@ -13,12 +13,12 @@ get:
             title: GetForkChoiceResponse
             type: object
             description: "Debugging context of fork choice"
-            required: [justified_checkpoint, finalized_checkpoint]
+            required: [justified_epoch, finalized_epoch]
             properties:
-              justified_checkpoint:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Checkpoint'
-              finalized_checkpoint:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Checkpoint'
+              justified_epoch:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+              finalized_epoch:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               fork_choice_nodes:
                 type: array
                 description: "Fork choice nodes"


### PR DESCRIPTION
In https://github.com/ethereum/beacon-APIs/pull/232 it was agreed that we will return justified and finalized epochs instead of checkpoints. In https://github.com/ethereum/beacon-APIs/pull/232/commits/630fba53c11208e0ce21582b8b98d108b7e3a61b field names were changed, but types remained the same. For an unknown reason https://github.com/ethereum/beacon-APIs/pull/232/commits/15b6561d0dccd4577b6725994f6ea733eb808046 changed field names back to checkpoints and that's what got merged. This PR sets the correct names and types.