### PR TITLE
Add /eth/v0/beacon/light_client/instant_update

### DIFF
--- a/apis/beacon/light_client/instant_update.yaml
+++ b/apis/beacon/light_client/instant_update.yaml
@@ -1,0 +1,59 @@
+get:
+  operationId: getLightClientInstantUpdate
+  summary: Get a `LightClientInstantUpdate` for the given (recent) block header
+  description: |
+    Requests the best [`LightClientInstantUpdate`](../../../types/altair/light_client.yaml#/Altair/LightClientInstantUpdate) known by the server for the given block header.
+    Depending on the `Accept` header it can be returned either as JSON or SSZ-serialized bytes.
+
+    Servers providing this endpoint SHOULD always listen to the sync committee signature gossip and collect individual signatures. On request the best BLS
+    signature is aggregated and returned for the specified (recent) block header. When a new block appears, the previously known best sync aggregate for its
+    parent is compared against the sync aggregate found in the new block and replaced if the canonical one is better. Best sync aggregates are retained and
+    served for the 16 most recent slots.
+    Note that since always listening to the signature gossip costs some resources, it is acceptable to only start listening once this endpoint is called
+    and stop listening if it is not called for an extended period of time.
+  tags:
+    - Beacon
+  parameters:
+    - name: block_root
+      in: path
+      required: true
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/BlockRoot'
+  responses:
+    "200":
+      description: Success
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+      content:
+        application/json:
+          schema:
+            title: GetLightClientInstantUpdateResponse
+            type: object
+            properties:
+              version:
+                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
+              data:
+                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientInstantUpdate'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `LightClientInstantUpdate` bytes. Use Accept header to choose this response type"
+    "404":
+      description: "No `LightClientInstantUpdate` is available for given block root"
+      content:
+        application/json:
+          schema:
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            example:
+              code: 404
+              message: "LC instant update unavailable"
+    "406":
+      description: Unacceptable media type
+      content:
+        application/json:
+          schema:
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            example:
+              code: 406
+              message: "Accepted media type not supported"
+    "500":
+      $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -113,7 +113,7 @@ paths:
     $ref: "./apis/beacon/light_client/finality_update.yaml"
   /eth/v1/beacon/light_client/optimistic_update:
     $ref: "./apis/beacon/light_client/optimistic_update.yaml"
-  /eth/v0/beacon/light_client/instant_update:
+  /eth/v0/beacon/light_client/instant_update/{block_root}:
     $ref: "./apis/beacon/light_client/instant_update.yaml"
   /eth/v1/beacon/pool/attestations:
     $ref: "./apis/beacon/pool/attestations.yaml"

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -113,6 +113,8 @@ paths:
     $ref: "./apis/beacon/light_client/finality_update.yaml"
   /eth/v1/beacon/light_client/optimistic_update:
     $ref: "./apis/beacon/light_client/optimistic_update.yaml"
+  /eth/v0/beacon/light_client/instant_update:
+    $ref: "./apis/beacon/light_client/instant_update.yaml"
   /eth/v1/beacon/pool/attestations:
     $ref: "./apis/beacon/pool/attestations.yaml"
   /eth/v1/beacon/pool/attester_slashings:
@@ -280,6 +282,8 @@ components:
       $ref: './types/altair/light_client.yaml#/Altair/LightClientFinalityUpdate'
     Altair.LightClientOptimisticUpdate:
       $ref: './types/altair/light_client.yaml#/Altair/LightClientOptimisticUpdate'
+    Altair.LightClientInstantUpdate:
+      $ref: './types/altair/light_client.yaml#/Altair/LightClientInstantUpdate'
     Altair.SignedBeaconBlock:
       $ref: './types/altair/block.yaml#/Altair/SignedBeaconBlock'
     Altair.BeaconBlock:

--- a/types/altair/light_client.yaml
+++ b/types/altair/light_client.yaml
@@ -75,3 +75,18 @@ Altair:
         $ref: './sync_aggregate.yaml#/Altair/SyncAggregate'
       signature_slot:
         $ref: '../primitive.yaml#/Uint64'
+  LightClientInstantUpdate:
+    type: object
+    properties:
+      best_sync_aggregate:
+        allOf:
+          - $ref: './sync_aggregate.yaml#/Altair/SyncAggregate'
+          - description: "Best available sync aggregate for requested header"
+      signature_slot:
+        allOf:
+          - $ref: '../primitive.yaml#/Uint64'
+          - description: "Signature slot of the best sync aggregate"
+      new_head_header:
+        allOf:
+          - $ref: '../block.yaml#/BeaconBlockHeader'
+          - description: "Latest head block header (only present if not the same as the one the sync aggregate refers to)"


### PR DESCRIPTION
This PR adds a `/eth/v0/beacon/light_client/instant_update` feature that allows optimistic light clients to operate with only a few seconds of delay as opposed to `/eth/v1/beacon/light_client/optimistic_update` which introduces a full block of delay. Security is not affected by the latest sync committee signature being canonized in the next block and therefore it is possible for the serving node to always listen to the sync committee signature gossip (just like it does when it is on the sync committee) and provide sync aggregates for the current head as soon as signatures are available.
The endpoint receives a `block_root` parameter and when asked about the current head, assuming that the client already has the header, returns only the current best aggregate. If an older `block_root` is specified then the most recent head header is also returned. This makes sense because the final best signature for a given block can typically be determined when its child appears, in which case the polling client is notified that the result can be considered final and the instant update for the returned new head should be polled next time.
When implemented as an `eventstream`, the streaming updates should refer to the `block_root` of the head known at the time when the last update was sent, meaning that whenever a new block appears the best signature for its parent and the header of the new head should be sent. Until a new block arrives, new updates containing only `best_sync_aggregate` and `signature_slot` are sent as soon as more signatures are available. A short (<100ms) delay is acceptable in order to avoid sending up to 512 updates per slot as the individual signatures arrive.