### PR TITLE
Add bls_to_execution_changes to blinded blocks.

### DIFF
--- a/types/capella/block.yaml
+++ b/types/capella/block.yaml
@@ -73,6 +73,10 @@ Capella:
         properties:
           execution_payload_header:
             $ref: './execution_payload.yaml#/Capella/ExecutionPayloadHeader'
+          bls_to_execution_changes:
+            type: array
+            items:
+              $ref: '../bls_to_execution_change.yaml#/SignedBLSToExecutionChange'
 
   BlindedBeaconBlock:
     description: "A variant of the the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblock) object from the CL Capella spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."


### PR DESCRIPTION
Add the `bls_to_execution_changes` item to blinded Capella beacon blocks.