### PR TITLE
feat(ci): use same origin for oapi definitions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,35 @@ on:
       - "master"
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      releases: ${{ steps.releases.outputs.releases }}
+    steps:
+      - id: releases
+        run: |
+          echo "releases=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{github.repository}}/releases?per_page=100" | jq -c '[.[].tag_name]')" >> $GITHUB_OUTPUT
+  releases:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: ${{fromJson(needs.setup.outputs.releases)}}
+    steps:
+      - uses: dsaltares/fetch-gh-release-asset@1.1.0
+        with:
+          version: 'tags/${{ matrix.release }}'
+          file: 'beacon-node-oapi.json'
+          target: 'deploy/releases/${{ matrix.release }}/beacon-node-oapi.json'
+      - name: Save releases (artifact)
+        uses: actions/upload-artifact@v3
+        with:
+          name: releases
+          retention-days: 7
+          path: |
+            deploy/releases
   deploy:
+    needs: releases
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +45,12 @@ jobs:
           mkdir ./deploy
           cp -r dist ./deploy
           cp -r assets ./deploy
-          cp -r index.html ./deploy
+          cp index.html ./deploy
+      - name: Restore releases
+        uses: actions/download-artifact@v3
+        with:
+          name: releases
+          path: deploy/releases
       - name: Bundle spec
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
       - name: Publish to Github Pages

--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ https://www.npmjs.com/package/@chainsafe/eth2.0-api-wrapper
 In SwaggerUIBundle configuration (inside index.html file), add another entry in "urls" field (SwaggerUI will load first item as default).
 Entry should be in following format(replace `<tag>` with real tag name from step 1.):
 ```javascript
-         {url: "https://github.com/ethereum/beacon-APIs/releases/download/<tag>/beacon-node-oapi.yaml", name: "<tag>"},
+         {url: "./releases/<tag>/beacon-node-oapi.json", name: "<tag>"},
 ```

--- a/index.html
+++ b/index.html
@@ -47,11 +47,11 @@
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
         urls: [
-          {url: "https://github.com/ethereum/beacon-APIs/releases/download/v2.3.0/beacon-node-oapi.json", name: "v2.3.0"},
-          {url: "https://github.com/ethereum/beacon-APIs/releases/download/v2.2.0/beacon-node-oapi.json", name: "v2.2.0"},
-          {url: "https://github.com/ethereum/beacon-APIs/releases/download/v2.1.0/beacon-node-oapi.json", name: "v2.1.0"},
-          {url: "https://github.com/ethereum/beacon-APIs/releases/download/v2.0.0/beacon-node-oapi.json", name: "v2.0.0"},
-          {url: "https://github.com/ethereum/beacon-APIs/releases/download/v1/beacon-node-oapi.yaml", name: "v1"},
+          {url: "./releases/v2.3.0/beacon-node-oapi.json", name: "v2.3.0"},
+          {url: "./releases/v2.2.0/beacon-node-oapi.json", name: "v2.2.0"},
+          {url: "./releases/v2.1.0/beacon-node-oapi.json", name: "v2.1.0"},
+          {url: "./releases/v2.0.0/beacon-node-oapi.json", name: "v2.0.0"},
+          {url: "./releases/v1/beacon-node-oapi.json", name: "v1"},
           {url: "./beacon-node-oapi.yaml", name: "dev"}
         ],
         basePath: "/",
@@ -67,13 +67,7 @@
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout",
-        requestInterceptor: function() {
-          if(this.url.startsWith("http")) {
-            this.url = "https://api.allorigins.win/raw?url=" + this.url; // will change the URL used.
-          }
-          return this;
-        }
+        layout: "StandaloneLayout"
    })
       // End Swagger UI call region
 


### PR DESCRIPTION
Avoid using the CORS proxy by bundling the releases into the github pages deployment.

- pages deployed [example](https://savid.github.io/beacon-APIs/)
- deploy action run [example](https://github.com/Savid/beacon-APIs/actions/runs/3690288991)

resolves #280 