### PR TITLE
Add version property to getPoolBLSToExecutionChanges

### DIFF
--- a/apis/beacon/pool/bls_to_execution_changes.yaml
+++ b/apis/beacon/pool/bls_to_execution_changes.yaml
@@ -13,6 +13,8 @@ get:
             title: GetPoolBLSToExecutionChangesResponse
             type: object
             properties:
+              version:
+                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Version'
               data:
                 type: array
                 items:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -81,3 +81,9 @@ Committee:
       description: "List of validator indices assigned to this committee"
       items:
         $ref: './primitive.yaml#/Uint64'
+
+Version:
+  description: Fork name
+  type: string
+  enum: [phase0, altair, bellatrix, capella]
+  example: "phase0"


### PR DESCRIPTION
A beacon node must _guess_ with what fork BLSToExecutionChanges messages are signed on. Assuming the current fork is a good guess, but it's still a guess. I find it sound to allow for clients to specify a fork, which allows:
- error-less submission around fork boundaries
- allow to submit BLSToExecutionChanges early ahead of the fork. In Lodestar's operation pool we hold early messages until their fork comes.

Since the API is batched this PR assumes all messages are signed at the same fork, which is a good assumption IMO. Else it would be a bit ugly to support, while this PR mimics the response format of versioned APIs.