### PR TITLE
Add source param to getLightClientOptimisticUpdate

### DIFF
--- a/apis/beacon/light_client/optimistic_update.yaml
+++ b/apis/beacon/light_client/optimistic_update.yaml
@@ -8,6 +8,24 @@ get:
     Servers SHOULD provide results as defined in [`create_light_client_optimistic_update`](https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/light-client/full-node.md#create_light_client_optimistic_update).
   tags:
     - Beacon
+  parameters:
+    - name: source
+      in: query
+      default: block
+      description: |
+        Source to produce retrieve the SyncAggregate from. Valid values are:
+        - `block` (default): Get SyncAggregate from current's head block body, `body.sync_aggregate`
+
+        - `signedcontributionandproof_pool`: Construct SyncAggregate from aggregating `SignedContributionAndProof`
+          objects in the node's pool received from the gossip topic `sync_committee_contribution_and_proof`.
+          MUST aggregate messages with `message.contribution.slot == current_slot` and `message.contribution.beacon_block_root == head_root`.
+  
+        - `synccommitteemessage_pool`: Construct SyncAggregate from aggregating `SyncCommitteeMessage` objects in the
+          node's pool received from the gossip topics `sync_committee_{subnet_id}`. MUST aggregate messages with`slot == current_slot`
+          and `beacon_block_root == head_root`. After receiving a `signatures` request, the node SHOULD subscribe to
+          all sync committee subnets.
+      schema:
+        $ref: "../../beacon-node-oapi.yaml#/components/schemas/SyncAggregateSource"
   responses:
     "200":
       description: Success

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -335,6 +335,8 @@ components:
       $ref: './types/rewards.yaml#/BlockRewards'
     AttestationsRewards:
       $ref: './types/rewards.yaml#/AttestationsRewards'
+    SyncAggregateSource:
+      $ref: './types/api.yaml#/SyncAggregateSource'
 
   parameters:
     StateId:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -81,3 +81,8 @@ Committee:
       description: "List of validator indices assigned to this committee"
       items:
         $ref: './primitive.yaml#/Uint64'
+
+SyncAggregateSource:
+  type: string
+  enum: ["block", "signedcontributionandproof_pool", "synccommitteemessage_pool"]
+  example: block


### PR DESCRIPTION
- Alternative approach to https://github.com/ethereum/beacon-APIs/pull/270

Route `getLightClientOptimisticUpdate` exposes a `LightClientOptimisticUpdate` produced with the SyncAggregate of the head block. This PR allows to customize this behaviour to support consumers that need a more "timely" SyncAggregate.

Proposed values of `source` param:
 - `block` (default): Get SyncAggregate from current's head block body, `body.sync_aggregate`

- `signedcontributionandproof_pool`: Construct SyncAggregate from aggregating `SignedContributionAndProof` objects in the node's pool received from the gossip topic `sync_committee_contribution_and_proof`. MUST aggregate messages with `message.contribution.slot == current_slot` and `message.contribution.beacon_block_root == head_root`.
  
- `synccommitteemessage_pool`: Construct SyncAggregate from aggregating `SyncCommitteeMessage` objects in the node's pool received from the gossip topics `sync_committee_{subnet_id}`. MUST aggregate messages with`slot == current_slot` and `beacon_block_root == head_root`. After receiving a `signatures` request, the node SHOULD subscribe to all sync committee subnets.

Since `source` param is optional and defaults to `block` I guess this is non-breaking change with the current rules of the repo right?