### PR TITLE
Updated version for v.2.4.0 release of beacon-apis.

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -21,7 +21,7 @@ info:
 
     Note that it is possible for a field to be added to an endpoint's data or metadata without an increase in the version number.
 
-  version: "v2.4.0 - Eth2Spec v1.3.0"
+  version: "v2.4.0 - Ethereum Proof-of-Stake Consensus Specification v1.3.0"
   contact:
     name: Ethereum Github
     url: https://github.com/ethereum/beacon-apis/issues

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -21,7 +21,7 @@ info:
 
     Note that it is possible for a field to be added to an endpoint's data or metadata without an increase in the version number.
 
-  version: "Dev - Eth2Spec v1.1.0"
+  version: "v2.4.0 - Eth2Spec v1.3.0"
   contact:
     name: Ethereum Github
     url: https://github.com/ethereum/beacon-apis/issues


### PR DESCRIPTION
Update version for release, and referencing 1.3.0 of consensus-spec.