### PR TITLE
Add optional basic/bearer authentication

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -195,8 +195,19 @@ paths:
   /eth/v1/events:
     $ref: "./apis/eventstream/index.yaml"
 
+security:
+  - {}
+  - BasicAuth: []
+  - BearerAuth: []
 
 components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    BearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     BeaconState:
       $ref: './types/state.yaml#/BeaconState'


### PR DESCRIPTION
This will enable the "Authorize" button on Swagger UI. Note that authentication **is optional** and doesn't have to be set. 
But this is useful if you want to use the UI to interact with endpoints that are protected with Basic Auth or Bearer tokens. 


![](https://cdn.discordapp.com/attachments/1033811855573008407/1071120323338055732/image.png)


Example of how the change looks like: https://skylenet.github.io/beacon-APIs/?urls.primaryName=dev 

Just to clarify the following: 

```yaml
security:
  - {}  
  - BasicAuth: []
  - BearerAuth: []
```

`{}` means that no auth can be also used. 