### PR TITLE
Remove array from attestation rewards response

### DIFF
--- a/apis/beacon/rewards/attestations.yaml
+++ b/apis/beacon/rewards/attestations.yaml
@@ -38,9 +38,7 @@ post:
               finalized:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
-                type: array
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/AttestationsRewards"
-                  
     "400":
       description: "Invalid get attestations rewards request"
       content:

--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -18,18 +18,18 @@ SyncCommitteeRewards:
           - description: "sync committee reward in gwei for the validator"
 
 AttestationsRewards:
+  type: object
   description: "Rewards info for attestations"
-  type: array
-  items:
-    properties:
-      ideal_rewards:
-        type: array
-        items:
-          $ref: ./rewards.yaml#/IdealAttestationRewards
-      total_rewards:
-        type: array
-        items:
-          $ref: ./rewards.yaml#/AttestationRewards
+  required: ["ideal_rewards", "total_rewards"]
+  properties:
+    ideal_rewards:
+      type: array
+      items:
+        $ref: ./rewards.yaml#/IdealAttestationRewards
+    total_rewards:
+      type: array
+      items:
+        $ref: ./rewards.yaml#/AttestationRewards
 
 AttestationRewards:
   type: object


### PR DESCRIPTION
There was an extra layer of unnecessary array nesting in the attestation rewards response:

```json
{
  "data": [
    {"ideal_rewards": [], "total_rewards": []}
  ]
}
```

The `data` list should always have 1 element, because the real lists are contained in `ideal_rewards` and `total_rewards`. Therefore this structure is more appropriate:

```json
{
  "data": {"ideal_rewards": [], "total_rewards": []}
}
```

This is already implemented by Lighthouse in https://github.com/sigp/lighthouse/pull/3822.