### PR TITLE
Make fork choice validity enum lower case

### DIFF
--- a/types/fork_choice.yaml
+++ b/types/fork_choice.yaml
@@ -22,7 +22,7 @@ Node:
       $ref: './primitive.yaml#/Uint64'
     validity:
       type: string
-      enum: [VALID, INVALID, OPTIMISTIC]
+      enum: [valid, invalid, optimistic]
     execution_block_hash:
       allOf:
         - $ref: './primitive.yaml#/Root'


### PR DESCRIPTION
All enums are lower case but this has been merged as UPPER CASE.