### PR TITLE
Added withdrawals endpoint to fetch withdrawals from a parent state

### DIFF
--- a/apis/builder/states/expected_withdrawals.yaml
+++ b/apis/builder/states/expected_withdrawals.yaml
@@ -1,0 +1,61 @@
+get:
+  operationId: "getNextWithdrawals"
+  summary: "Get the withdrawals that are to be included for the block built on the specified state."
+  description: |
+    Get the withdrawals computed from the specified state, that will be included in the block 
+    that gets built on the specified state.
+  tags:
+    - Builder
+  parameters:
+    - name: state_id
+      in: path
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+    - name: proposal_slot
+      description: "The slot that a block is being built for, with the specified state as the parent. Defaults to the slot after the parent state if not specified."
+      in: query
+      required: false
+      allowEmptyValue: false
+      schema:
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            title: GetNextWithdrawalsResponse
+            type: object
+            properties:
+              execution_optimistic:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
+              data:
+                type: array
+                items:
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.Withdrawal'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized Withdrawals list. Use Accept header to choose this response type"
+    "400":
+      description: "An error occurred preparing the withdrawals from the specified state for the proposal slot."
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+              - example:
+                  code: 400
+                  message: "The specified state is not a capella state."
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 404
+            message: "State not found"
+    "500":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -39,6 +39,8 @@ servers:
 tags:
   - name: Beacon
     description: Set of endpoints to query beacon chain.
+  - name: Builder
+    description: Set of endpoints specific to building blocks.
   - name: Config
     description: Endpoints to query chain configuration, specification, and fork schedules.
   - name: Debug
@@ -125,6 +127,9 @@ paths:
     $ref: "./apis/beacon/pool/voluntary_exists.yaml"
   /eth/v1/beacon/pool/bls_to_execution_changes:
     $ref: "./apis/beacon/pool/bls_to_execution_changes.yaml"
+
+  /eth/v1/builder/states/{state_id}/expected_withdrawals:
+    $ref: "./apis/builder/states/expected_withdrawals.yaml"
 
   /eth/v2/debug/beacon/states/{state_id}:
     $ref: './apis/debug/state.v2.yaml'
@@ -341,6 +346,8 @@ components:
       $ref: './types/capella/light_client.yaml#/Capella/LightClientFinalityUpdate'
     Capella.LightClientOptimisticUpdate:
       $ref: './types/capella/light_client.yaml#/Capella/LightClientOptimisticUpdate'
+    Capella.Withdrawal:
+      $ref: './types/withdrawal.yaml#/Withdrawal'
     Node:
       $ref: './types/fork_choice.yaml#/Node'
     ExtraData:


### PR DESCRIPTION
Added into a new route, `/eth/v1/builder`, as it's different to the existing beacon state fetch paradigm, and a new Tag for builders seems appropriate.

This endpoint is probably suited to allowing for returning SSZ via octet-stream also, so added that in. The idea would be similar to blocks, it would just return the data object as the SSZ result.

It would be possible to add withdrawals_root, but it'd be at the same level as finalized, so it'd be a little less clean. I've left that out for now.

Fixes #301.