### PR TITLE
SSE for payload attributes

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -32,6 +32,7 @@ get:
             - contribution_and_proof
             - light_client_finality_update
             - light_client_optimistic_update
+            - payload_attributes
   responses:
     "200":
       description: Opened SSE stream.
@@ -91,6 +92,32 @@ get:
               value: |
                 event: light_client_optimistic_update
                 data: {"version":"phase0", "data": {"attested_header": {"beacon": {"slot":"1", "proposer_index":"1", "parent_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "state_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "body_root":"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}}, "sync_aggregate": {"sync_committee_bits":"0x01", "sync_committee_signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}, "signature_slot":"1"}}
+            payload_attributes:
+              description: |
+                The node has computed new payload attributes for execution payload building.
+
+                This event gives block builders and relays sufficient information to construct or
+                verify a block at `proposal_slot`. The meanings of the fields are:
+
+                - `version`: the identifier of the beacon hard fork at `proposal_slot`, e.g.
+                  `"bellatrix"`, `"capella"`.
+                - `proposal_slot`: the slot at which a block using these payload attributes may be
+                   built.
+                - `parent_block_root`: the beacon block root of the parent block to be built upon.
+                - `parent_block_number`: the execution block number of the parent block.
+                - `parent_block_hash`: the execution block hash of the parent block.
+                - `proposer_index`: the validator index of the proposer at `proposal_slot` on
+                   the chain identified by `parent_block_root`.
+                - `payload_attributes`: beacon-style encoding of `PayloadAttributesV<N>` as
+                   defined by the `execution-apis` specification. The version `N` must match the
+                   payload attributes for the hard fork matching `version`.
+                   The object here must have equivalent fields to its counterpart in
+                   `execution-apis` with two differences: 1) `snake_case` identifiers must be used
+                   rather than `camelCase`; 2) integers must be encoded as quoted decimals rather
+                   than big-endian hex.
+              value: |
+                event: payload_attributes
+                data: {"version": "capella", "data": {"proposer_index": "123", "proposal_slot": "10", "proposal_block_number": "9", "parent_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "parent_block_hash": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "payload_attributes": {"timestamp": "123456", "prev_randao": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "suggested_fee_recipient": "0x0000000000000000000000000000000000000000", "withdrawals": [{"index": "5", "validator_index": "10", "address": "0x0000000000000000000000000000000000000000", "amount": "15640"}]}}},
     "400":
       description: "The topics supplied could not be parsed"
       content:

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -108,10 +108,10 @@ get:
                 - `parent_block_hash`: the execution block hash of the parent block.
                 - `proposer_index`: the validator index of the proposer at `proposal_slot` on
                    the chain identified by `parent_block_root`.
-                - `payload_attributes`: beacon-style encoding of `PayloadAttributesV<N>` as
+                - `payload_attributes`: beacon API encoding of `PayloadAttributesV<N>` as
                    defined by the `execution-apis` specification. The version `N` must match the
                    payload attributes for the hard fork matching `version`.
-                   The object here must have equivalent fields to its counterpart in
+                   The beacon API encoded object must have equivalent fields to its counterpart in
                    `execution-apis` with two differences: 1) `snake_case` identifiers must be used
                    rather than `camelCase`; 2) integers must be encoded as quoted decimals rather
                    than big-endian hex.

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -115,6 +115,10 @@ get:
                    `execution-apis` with two differences: 1) `snake_case` identifiers must be used
                    rather than `camelCase`; 2) integers must be encoded as quoted decimals rather
                    than big-endian hex.
+
+                The frequency at which this event is sent may depend on beacon node configuration.
+                The fee recipient may also be set via beacon node config, but should likely be
+                ignored by block builders and most other API consumers.
               value: |
                 event: payload_attributes
                 data: {"version": "capella", "data": {"proposer_index": "123", "proposal_slot": "10", "proposal_block_number": "9", "parent_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "parent_block_hash": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "payload_attributes": {"timestamp": "123456", "prev_randao": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "suggested_fee_recipient": "0x0000000000000000000000000000000000000000", "withdrawals": [{"index": "5", "validator_index": "10", "address": "0x0000000000000000000000000000000000000000", "amount": "15640"}]}}},


### PR DESCRIPTION
Closes #244.

Define a new server sent event (SSE) for payload attributes.

The difficult part of specifying this event was deciding on an encoding for the payload attributes. Payload attributes presently only exist in the `execution-specs` repo where they are always encoded with `camelCase` idents and big-endian hex integers. We have two options for encoding them here:

1. Use the `execution-apis` encoding and break consistency with the rest of `beacon-apis`.
2. Define a new encoding for payload attributes here in order to maintain consistency.

There are pros and cons in favour of each approach. Option (1) potentially minimises the number of encodings that clients need to maintain for the payload attributes data structure, which could be good for implementation complexity. On the other hand, the break in consistency might make it hard for implementations to use a different encoding for _just these fields_. After discussions with @rolfyone we came to the conclusion that the consistency of option (2) is preferable, and not difficult to implement in either Lighthouse or Teku. **We would like feedback from other CL devs about their preference as well.**

The way the events are currently specified is quite loose, so I've added some extra descriptive text to convey the choice of encoding as clearly as possible. Perhaps in future it would be good to clean up the events API so that the returned events are given full schemas in their own right.