### PR TITLE
Add 501 error response to submitSyncCommitteeSelections

### DIFF
--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -37,5 +37,7 @@ post:
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
+    "501":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/NotImplementedError'
     "503":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/CurrentlySyncing'


### PR DESCRIPTION
Same as for `submitBeaconCommitteeSelections`,  `submitSyncCommitteeSelections` API is not implemented by a consensus client and should return 501.

https://github.com/ethereum/beacon-APIs/blob/f087fbf2764e657578a6c29bdf0261b36ee8db1e/apis/validator/beacon_committee_selections.yaml#L40-L41