### PR TITLE
Update `ethereum/consensus-specs` refs to `v1.3.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ API browser: [https://ethereum.github.io/beacon-APIs/](https://ethereum.github.i
 
 ## Outline
 
-This document outlines an application programming interface (API) which is exposed by a beacon node implementation
- which aims to facilitate [Phase 0](https://github.com/ethereum/consensus-specs#phase-0) of the Ethereum consensus layer.
+This document outlines an application programming interface (API) which is exposed by a beacon node implementation of the Ethereum [consensus layer specifications](https://github.com/ethereum/consensus-specs).
 
 The API is a REST interface, accessed via HTTP. The API should not, unless protected by additional security layers, be exposed to the public Internet as the API includes multiple endpoints which could open your node to denial-of-service (DoS) attacks through endpoints triggering heavy processing.
  Currently, the only supported return data type is JSON.
@@ -17,13 +16,13 @@ The API is a REST interface, accessed via HTTP. The API should not, unless prote
 The beacon node (BN) maintains the state of the beacon chain by communicating with other beacon nodes in the Ethereum network.
 Conceptually, it does not maintain keypairs that participate with the beacon chain.
 
-The validator client (VC) is a conceptually separate entity which utilizes private keys 
+The validator client (VC) is a conceptually separate entity which utilizes private keys
 to perform validator related tasks, called "duties", on the beacon chain.
  These duties include the production of beacon blocks and signing of attestations.
 
 The goal of this specification is to promote interoperability between various beacon node implementations.
 
-## Render 
+## Render
 To render spec in browser you will need any http server to load `index.html` file
 in root of the repo.
 
@@ -49,10 +48,10 @@ And api spec will render on [http://localhost:8000](http://localhost:8000).
 
 Local changes will be observable if "dev" is selected in the "Select a definition" drop-down in the web UI.
 
-Users may need to tick the "Disable Cache" box in their browser's developer tools to see changes after modifying the source. 
+Users may need to tick the "Disable Cache" box in their browser's developer tools to see changes after modifying the source.
 
 ## Contributing
-Api spec is checked for lint errors before merge. 
+Api spec is checked for lint errors before merge.
 
 To run lint locally, install linter with
 ```
@@ -64,7 +63,7 @@ yarn global add @redocly/cli
 ```
 and run lint with
 ```
-redocly lint beacon-node-oapi.yaml 
+redocly lint beacon-node-oapi.yaml
 ```
 
 ## Implementations

--- a/apis/beacon/light_client/bootstrap.yaml
+++ b/apis/beacon/light_client/bootstrap.yaml
@@ -2,10 +2,10 @@ get:
   operationId: getLightClientBootstrap
   summary: Get `LightClientBootstrap` structure for a requested block root
   description: |
-    Requests the [`LightClientBootstrap`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#lightclientbootstrap) structure corresponding to a given post-Altair beacon block root.
+    Requests the [`LightClientBootstrap`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#lightclientbootstrap) structure corresponding to a given post-Altair beacon block root.
     Depending on the `Accept` header it can be returned either as JSON or SSZ-serialized bytes.
 
-    Servers SHOULD provide results as defined in [`create_light_client_bootstrap`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/full-node.md#create_light_client_bootstrap). To fulfill a request, the requested block's post state needs to be known.
+    Servers SHOULD provide results as defined in [`create_light_client_bootstrap`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/full-node.md#create_light_client_bootstrap). To fulfill a request, the requested block's post state needs to be known.
   tags:
     - Beacon
   parameters:

--- a/apis/beacon/light_client/finality_update.yaml
+++ b/apis/beacon/light_client/finality_update.yaml
@@ -2,10 +2,10 @@ get:
   operationId: getLightClientFinalityUpdate
   summary: Get the latest known `LightClientFinalityUpdate`
   description: |
-    Requests the latest [`LightClientFinalityUpdate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#lightclientfinalityupdate) known by the server.
+    Requests the latest [`LightClientFinalityUpdate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#lightclientfinalityupdate) known by the server.
     Depending on the `Accept` header it can be returned either as JSON or SSZ-serialized bytes.
 
-    Servers SHOULD provide results as defined in [`create_light_client_finality_update`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/full-node.md#create_light_client_finality_update).
+    Servers SHOULD provide results as defined in [`create_light_client_finality_update`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/full-node.md#create_light_client_finality_update).
   tags:
     - Beacon
   responses:

--- a/apis/beacon/light_client/optimistic_update.yaml
+++ b/apis/beacon/light_client/optimistic_update.yaml
@@ -2,10 +2,10 @@ get:
   operationId: getLightClientOptimisticUpdate
   summary: Get the latest known `LightClientOptimisticUpdate`
   description: |
-    Requests the latest [`LightClientOptimisticUpdate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#lightclientoptimisticupdate) known by the server.
+    Requests the latest [`LightClientOptimisticUpdate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#lightclientoptimisticupdate) known by the server.
     Depending on the `Accept` header it can be returned either as JSON or SSZ-serialized bytes.
 
-    Servers SHOULD provide results as defined in [`create_light_client_optimistic_update`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/full-node.md#create_light_client_optimistic_update).
+    Servers SHOULD provide results as defined in [`create_light_client_optimistic_update`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/full-node.md#create_light_client_optimistic_update).
   tags:
     - Beacon
   responses:

--- a/apis/beacon/light_client/updates.yaml
+++ b/apis/beacon/light_client/updates.yaml
@@ -2,10 +2,10 @@ get:
   operationId: getLightClientUpdatesByRange
   summary: Get `LightClientUpdate` instances in a requested sync committee period range
   description: |
-    Requests the [`LightClientUpdate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#lightclientupdate) instances in the sync committee period range `[start_period, start_period + count)`, leading up to the current head sync committee period as selected by fork choice.
+    Requests the [`LightClientUpdate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#lightclientupdate) instances in the sync committee period range `[start_period, start_period + count)`, leading up to the current head sync committee period as selected by fork choice.
     Depending on the `Accept` header they can be returned either as JSON or SSZ-serialized bytes.
 
-    Servers SHOULD provide results as defined in [`create_light_client_update`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/full-node.md#create_light_client_update). They MUST respond with at least the earliest known result within the requested range, and MUST send results in consecutive order (by period). The response MUST NOT contain more than [`min(MAX_REQUEST_LIGHT_CLIENT_UPDATES, count)`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/p2p-interface.md#configuration) results.
+    Servers SHOULD provide results as defined in [`create_light_client_update`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/full-node.md#create_light_client_update). They MUST respond with at least the earliest known result within the requested range, and MUST send results in consecutive order (by period). The response MUST NOT contain more than [`min(MAX_REQUEST_LIGHT_CLIENT_UPDATES, count)`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/p2p-interface.md#configuration) results.
   tags:
     - Beacon
   parameters:

--- a/apis/beacon/states/fork.yaml
+++ b/apis/beacon/states/fork.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: "getStateFork"
   summary: "Get Fork object for requested state"
-  description: "Returns [Fork](https://github.com/ethereum/consensus-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#fork) object for state with given 'stateId'."
+  description: "Returns [Fork](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#fork) object for state with given 'stateId'."
   tags:
     - Beacon
     - ValidatorRequiredApi
@@ -45,4 +45,3 @@ get:
               message: "State not found"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
-

--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -3,9 +3,9 @@ get:
   summary: Get spec params.
   description: |
     Retrieve specification configuration used on this node.  The configuration should include:
-      - Constants for all hard forks known by the beacon node, for example the [phase 0](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#constants) and [altair](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#constants) values
-      - Presets for all hard forks supplied to the beacon node, for example the [phase 0](https://github.com/ethereum/consensus-specs/blob/dev/presets/mainnet/phase0.yaml) and [altair](https://github.com/ethereum/consensus-specs/blob/dev/presets/mainnet/altair.yaml) values
-      - Configuration for the beacon node, for example the [mainnet](https://github.com/ethereum/consensus-specs/blob/dev/configs/mainnet.yaml) values
+      - Constants for all hard forks known by the beacon node, for example the [phase 0](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#constants) and [altair](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#constants) values
+      - Presets for all hard forks supplied to the beacon node, for example the [phase 0](https://github.com/ethereum/consensus-specs/blob/v1.3.0/presets/mainnet/phase0.yaml) and [altair](https://github.com/ethereum/consensus-specs/blob/v1.3.0/presets/mainnet/altair.yaml) values
+      - Configuration for the beacon node, for example the [mainnet](https://github.com/ethereum/consensus-specs/blob/v1.3.0/configs/mainnet.yaml) values
 
     Values are returned with following format:
       - any value starting with 0x in the spec is returned as a hex string

--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -22,7 +22,7 @@ Altair:
 
   BeaconBlockBody:
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblockbody) object from the CL Altair spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#beaconblockbody) object from the CL Altair spec."
     properties:
       randao_reveal:
         allOf:
@@ -56,7 +56,7 @@ Altair:
         $ref: './sync_aggregate.yaml#/Altair/SyncAggregate'
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconblock) object from the CL Altair spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL Altair spec."
     allOf:
       - $ref: '#/Altair/BeaconBlockCommon'
       - type: object
@@ -66,7 +66,7 @@ Altair:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#signedbeaconblock) object envelope from the CL Altair spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Altair spec."
     properties:
       message:
         $ref: "#/Altair/BeaconBlock"

--- a/types/altair/light_client.yaml
+++ b/types/altair/light_client.yaml
@@ -3,21 +3,21 @@ Altair:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#constants) roots"
     minItems: 6
     maxItems: 6
   CurrentSyncCommitteeBranch:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#constants) roots"
     minItems: 5
     maxItems: 5
   NextSyncCommitteeBranch:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/light-client/sync-protocol.md#constants) roots"
     minItems: 5
     maxItems: 5
 

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -1,7 +1,7 @@
 Altair:
   BeaconState:
     type: object
-    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#beaconstate) object from the CL Altair spec."
+    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#beaconstate) object from the CL Altair spec."
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/altair/sync_aggregate.yaml
+++ b/types/altair/sync_aggregate.yaml
@@ -1,7 +1,7 @@
 Altair:
   SyncAggregate:
     type: object
-    description: "The [`SyncAggregate`](https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.1/specs/altair/beacon-chain.md#syncaggregate) object from the CL Altair spec."
+    description: "The [`SyncAggregate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#syncaggregate) object from the CL Altair spec."
     properties:
       sync_committee_bits:
         $ref: "../primitive.yaml#/BitList"

--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -1,6 +1,6 @@
 IndexedAttestation:
   type: object
-  description: "The [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#indexedattestation) object from the CL spec."
+  description: "The [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#indexedattestation) object from the CL spec."
   properties:
     attesting_indices:
       type: array
@@ -17,7 +17,7 @@ IndexedAttestation:
 
 Attestation:
   type: object
-  description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestation) object from the CL spec."
+  description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attestation) object from the CL spec."
   properties:
     aggregation_bits:
       $ref: "./primitive.yaml#/BitList"
@@ -31,7 +31,7 @@ Attestation:
 
 PendingAttestation:
   type: object
-  description: "The [`PendingAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#pendingattestation) object from the CL spec."
+  description: "The [`PendingAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#pendingattestation) object from the CL spec."
   properties:
     aggregation_bits:
       $ref: "./primitive.yaml#/BitList"
@@ -45,7 +45,7 @@ PendingAttestation:
 
 AttestationData:
   type: object
-  description: "The [`AttestationData`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestationdata) object from the CL spec."
+  description: "The [`AttestationData`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attestationdata) object from the CL spec."
   properties:
     slot:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/attester_slashing.yaml
+++ b/types/attester_slashing.yaml
@@ -1,6 +1,6 @@
 AttesterSlashing:
   type: object
-  description: "The [`AttesterSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/core/0_beacon-chain.md#attesterslashing) object from the CL spec."
+  description: "The [`AttesterSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attesterslashing) object from the CL spec."
   properties:
     attestation_1:
       $ref: './attestation.yaml#/IndexedAttestation'

--- a/types/bellatrix/block.yaml
+++ b/types/bellatrix/block.yaml
@@ -2,7 +2,7 @@ Bellatrix:
   BeaconBlockBodyCommon:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec."
     properties:
       randao_reveal:
         allOf:
@@ -44,7 +44,7 @@ Bellatrix:
             $ref: './execution_payload.yaml#/Bellatrix/ExecutionPayload'
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblock) object from the CL Bellatrix spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL Bellatrix spec."
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
@@ -54,7 +54,7 @@ Bellatrix:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec."
     properties:
       message:
         $ref: "#/Bellatrix/BeaconBlock"
@@ -62,7 +62,7 @@ Bellatrix:
         $ref: "../primitive.yaml#/Signature"
 
   BlindedBeaconBlockBody:
-    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec, which contains a transactions root rather than a full transactions list."
+    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec, which contains a transactions root rather than a full transactions list."
     allOf:
       - $ref: '#/Bellatrix/BeaconBlockBodyCommon'
       - type: object
@@ -71,7 +71,7 @@ Bellatrix:
             $ref: './execution_payload.yaml#/Bellatrix/ExecutionPayloadHeader'
 
   BlindedBeaconBlock:
-    description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconblock) object from the CL Bellatrix spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
+    description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL Bellatrix spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
@@ -81,7 +81,7 @@ Bellatrix:
 
   SignedBlindedBeaconBlock:
     type: object
-    description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
     properties:
       message:
         $ref: "#/Bellatrix/BlindedBeaconBlock"

--- a/types/bellatrix/execution_payload.yaml
+++ b/types/bellatrix/execution_payload.yaml
@@ -2,7 +2,7 @@ Bellatrix:
   ExecutionPayloadCommon:
     # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
     type: object
-    description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#executionpayload) object from the CL Bellatrix spec."
+    description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#executionpayload) object from the CL Bellatrix spec."
     properties:
       parent_hash:
         $ref: '../primitive.yaml#/Root'
@@ -41,7 +41,7 @@ Bellatrix:
             $ref: './transactions.yaml#/Bellatrix/Transactions'
 
   ExecutionPayloadHeader:
-    description: "The [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#executionpayloadheader) object from the CL Bellatrix spec."
+    description: "The [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#executionpayloadheader) object from the CL Bellatrix spec."
     allOf:
       - $ref: '#/Bellatrix/ExecutionPayloadCommon'
       - type: object

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -1,7 +1,7 @@
 Bellatrix:
   BeaconState:
     type: object
-    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#beaconstate) object from the Eth2.0 Bellatrix spec."
+    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#beaconstate) object from the Eth2.0 Bellatrix spec."
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -21,7 +21,7 @@ BeaconBlockCommon:
 
 BeaconBlockBody:
   type: object
-  description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockbody) object from the CL spec."
+  description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblockbody) object from the CL spec."
   properties:
     randao_reveal:
       allOf:
@@ -54,7 +54,7 @@ BeaconBlockBody:
 
 
 BeaconBlock:
-  description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
+  description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
   allOf:
     - $ref: '#/BeaconBlockCommon'
     - type: object
@@ -64,7 +64,7 @@ BeaconBlock:
 
 SignedBeaconBlock:
   type: object
-  description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL spec."
+  description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL spec."
   properties:
     message:
       $ref: "#/BeaconBlock"
@@ -72,7 +72,7 @@ SignedBeaconBlock:
       $ref: "./primitive.yaml#/Signature"
 
 BeaconBlockHeader:
-  description: "The [`BeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblockheader) object from the CL spec."
+  description: "The [`BeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblockheader) object from the CL spec."
   allOf:
     - $ref: './block.yaml#/BeaconBlockCommon'
     - type: object
@@ -84,7 +84,7 @@ BeaconBlockHeader:
 
 SignedBeaconBlockHeader:
   type: object
-  description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the CL spec."
+  description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the CL spec."
   properties:
     message:
       $ref: "./block.yaml#/BeaconBlockHeader"

--- a/types/bls_to_execution_change.yaml
+++ b/types/bls_to_execution_change.yaml
@@ -1,6 +1,6 @@
 BLSToExecutionChange:
   type: object
-  description: "The [`BLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#blstoexecutionchange) object from the CL spec."
+  description: "The [`BLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#blstoexecutionchange) object from the CL spec."
   properties:
     validator_index:
       $ref: "./primitive.yaml#/Uint64"
@@ -14,10 +14,9 @@ BLSToExecutionChange:
 
 SignedBLSToExecutionChange:
   type: object
-  description: "The [`SignedBLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#signedblstoexecutionchange) object from the CL spec."
+  description: "The [`SignedBLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#signedblstoexecutionchange) object from the CL spec."
   properties:
     message:
       $ref: "#/BLSToExecutionChange"
     signature:
       $ref: './primitive.yaml#/Signature'
-

--- a/types/capella/block.yaml
+++ b/types/capella/block.yaml
@@ -2,7 +2,7 @@ Capella:
   BeaconBlockBodyCommon:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec."
     properties:
       randao_reveal:
         allOf:
@@ -48,7 +48,7 @@ Capella:
               $ref: '../bls_to_execution_change.yaml#/SignedBLSToExecutionChange'
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/Capella/beacon-chain.md#beaconblock) object from the CL Capella spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL Capella spec."
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
@@ -58,7 +58,7 @@ Capella:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec."
     properties:
       message:
         $ref: "#/Capella/BeaconBlock"
@@ -66,7 +66,7 @@ Capella:
         $ref: "../primitive.yaml#/Signature"
 
   BlindedBeaconBlockBody:
-    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec, which contains a transactions root rather than a full transactions list."
+    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec, which contains a transactions root rather than a full transactions list."
     allOf:
       - $ref: '#/Capella/BeaconBlockBodyCommon'
       - type: object
@@ -79,7 +79,7 @@ Capella:
               $ref: '../bls_to_execution_change.yaml#/SignedBLSToExecutionChange'
 
   BlindedBeaconBlock:
-    description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconblock) object from the CL Capella spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
+    description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL Capella spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
@@ -89,7 +89,7 @@ Capella:
 
   SignedBlindedBeaconBlock:
     type: object
-    description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
     properties:
       message:
         $ref: "#/Capella/BlindedBeaconBlock"

--- a/types/capella/execution_payload.yaml
+++ b/types/capella/execution_payload.yaml
@@ -2,7 +2,7 @@ Capella:
   ExecutionPayloadCommon:
     # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
     type: object
-    description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#executionpayload) object from the CL Capella spec."
+    description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#executionpayload) object from the CL Capella spec."
     properties:
       parent_hash:
         $ref: '../primitive.yaml#/Root'
@@ -43,7 +43,7 @@ Capella:
             $ref: './withdrawals.yaml#/Capella/Withdrawals'
 
   ExecutionPayloadHeader:
-    description: "The [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#executionpayloadheader) object from the CL Capella spec."
+    description: "The [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#executionpayloadheader) object from the CL Capella spec."
     allOf:
       - $ref: '#/Capella/ExecutionPayloadCommon'
       - type: object

--- a/types/capella/light_client.yaml
+++ b/types/capella/light_client.yaml
@@ -3,7 +3,7 @@ Capella:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(EXECUTION_PAYLOAD_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/capella/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(EXECUTION_PAYLOAD_INDEX])`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/light-client/sync-protocol.md#constants) roots"
     minItems: 4
     maxItems: 4
 

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -1,7 +1,7 @@
 Capella:
   BeaconState:
     type: object
-    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#beaconstate) object from the Eth2.0 Capella spec."
+    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#beaconstate) object from the Eth2.0 Capella spec."
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/deposit.yaml
+++ b/types/deposit.yaml
@@ -1,6 +1,6 @@
 Deposit:
   type: object
-  description: "The [`Deposit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#deposit) object from the CL spec."
+  description: "The [`Deposit`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#deposit) object from the CL spec."
   properties:
     proof:
       type: array
@@ -14,7 +14,7 @@ Deposit:
       $ref: './deposit.yaml#/DepositData'
 DepositData:
   type: object
-  description: "The [`DepositData`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#depositdata) object from the CL spec."
+  description: "The [`DepositData`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#depositdata) object from the CL spec."
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'

--- a/types/eth1.yaml
+++ b/types/eth1.yaml
@@ -1,6 +1,6 @@
 Eth1Data:
   type: object
-  description: "The [`Eth1Data`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#eth1data) object from the CL spec."
+  description: "The [`Eth1Data`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#eth1data) object from the CL spec."
   properties:
     deposit_root:
       allOf:

--- a/types/misc.yaml
+++ b/types/misc.yaml
@@ -1,6 +1,6 @@
 Fork:
   type: object
-  description: "The [`Fork`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#fork) object from the CL spec."
+  description: "The [`Fork`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#fork) object from the CL spec."
   properties:
     previous_version:
       $ref: "./primitive.yaml#/ForkVersion"
@@ -11,7 +11,7 @@ Fork:
 
 Checkpoint:
   type: object
-  description: "The [`Checkpoint`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#checkpoint"
+  description: "The [`Checkpoint`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#checkpoint"
   properties:
     epoch:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -23,7 +23,7 @@ NetworkIdentity:
 
 MetaData:
   type: object
-  description: "Based on eth2 [Metadata object](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#metadata)"
+  description: "Based on eth2 [Metadata object](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#metadata)"
   required: ["seq_number", "attnets"]
   properties:
     seq_number:

--- a/types/proposer_slashing.yaml
+++ b/types/proposer_slashing.yaml
@@ -1,6 +1,6 @@
 ProposerSlashing:
   type: object
-  description: "The [`ProposerSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#proposerslashing) object from the CL spec."
+  description: "The [`ProposerSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#proposerslashing) object from the CL spec."
   properties:
     signed_header_1:
       $ref: './block.yaml#/SignedBeaconBlockHeader'

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -1,6 +1,6 @@
 BeaconState:
   type: object
-  description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
+  description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
   properties:
     genesis_time:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -103,7 +103,7 @@ AggregateAndProof:
 
 Aggregate:
   type: object
-  description: "The [`AggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#aggregateandproof) without selection_proof"
+  description: "The [`AggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#aggregateandproof) without selection_proof"
   properties:
     aggregator_index:
       $ref: './primitive.yaml#/Uint64'
@@ -112,7 +112,7 @@ Aggregate:
 
 
 SignedAggregateAndProof:
-  description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#signedaggregateandproof) object"
+  description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#signedaggregateandproof) object"
   properties:
     message:
       $ref: "#/AggregateAndProof"

--- a/types/voluntary_exit.yaml
+++ b/types/voluntary_exit.yaml
@@ -1,6 +1,6 @@
 VoluntaryExit:
   type: object
-  description: "The [`VoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#voluntaryexit) object from the CL spec."
+  description: "The [`VoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#voluntaryexit) object from the CL spec."
   properties:
     epoch:
       allOf:
@@ -13,10 +13,9 @@ VoluntaryExit:
 
 SignedVoluntaryExit:
   type: object
-  description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the CL spec."
+  description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the CL spec."
   properties:
     message:
       $ref: "#/VoluntaryExit"
     signature:
       $ref: './primitive.yaml#/Signature'
-

--- a/validator-flow.md
+++ b/validator-flow.md
@@ -19,7 +19,7 @@ If proposing block, then at immediate start of slot:
 2. Sign block
 3. [Submit SignedBeaconBlock](#/ValidatorRequiredApi/publishBlock) (BeaconBlock + signature)
 
-Monitor chain block reorganization events (TBD) as they could change block proposers. 
+Monitor chain block reorganization events (TBD) as they could change block proposers.
 If reorg is detected, ask for new proposer duties and proceed from 1.
 
 ### Attestation
@@ -29,7 +29,7 @@ Result are array of objects with validator, his committee and attestation slot.
 
 Attesting:
 1. Upon receiving duty, have beacon node prepare committee subnet
-    - [Check if aggregator by computing `slot_signature`](https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#attestation-aggregation)
+    - [Check if aggregator by computing `slot_signature`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#attestation-aggregation)
     - [Ask beacon node to prepare your subnet](#/ValidatorRequiredApi/prepareBeaconCommitteeSubnet)
       -- Note, validator client only needs to submit one call to
       `prepareBeaconCommitteeSubnet` per committee/slot its validators have
@@ -46,5 +46,5 @@ Attesting:
     - [Fetch aggregated Attestation](#/ValidatorRequiredApi/getAggregatedAttestation) from Beacon Node you've subscribed to your subnet
     - [Publish SignedAggregateAndProofs](#/ValidatorRequiredApi/publishAggregateAndProofs)
 
-Monitor chain block reorganization events (TBD) as they could change attesters and aggregators. 
+Monitor chain block reorganization events (TBD) as they could change attesters and aggregators.
 If reorg is detected, ask for new attester duties and proceed from 1..


### PR DESCRIPTION
Bump references to consensus specs to Capella release.