### PR TITLE
Added historical summaries to Capella beacon state.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,9 @@ These endpoints have been added or updated since the last release.
 
 There are likely to be descriptions etc outside of the list below, but new query parameters, changes to headers, new endpoints should be listed.
 
-| Endpoint                                                                                                                                                             | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
-
+| Endpoint                                                                                                                        | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
+|---------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
+| [#316](https://github.com/ethereum/beacon-APIs/pull/316) `/eth/v2/debug/beacon/states` added `historical_summaries` to response |                                                  |                                                   |                                                    |                                                 |                                           |
 
 The Following are no longer in the Standard API, removed since the latest version.
 

--- a/types/capella/historical_summary.yaml
+++ b/types/capella/historical_summary.yaml
@@ -1,0 +1,9 @@
+Capella:
+  HistoricalSummary:
+    type: object
+    description:  "The [`HistoricalSummary`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#historicalsummary) object from the CL Capella spec."
+    properties:
+      block_summary_root:
+        $ref: '../primitive.yaml#/Root'
+      state_summary_root:
+        $ref: '../primitive.yaml#/Root'

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -25,7 +25,7 @@ Capella:
           $ref: '../primitive.yaml#/Root'
       historical_roots:
         type: array
-        description: "Variable length list, maximum 16777216 items"
+        description: "Variable length list, maximum 16777216 items. Frozen in Capella, replaced by historical_summaries."
         items:
           $ref: '../primitive.yaml#/Root'
       eth1_data:
@@ -86,3 +86,8 @@ Capella:
         $ref: "../primitive.yaml#/Uint64"
       next_withdrawal_validator_index:
         $ref: "../primitive.yaml#/Uint64"
+      historical_summaries:
+          type: array
+          items:
+            $ref: "./historical_summary.yaml#/Capella/HistoricalSummary"
+          description: "Variable length list, maximum 16777216 items"


### PR DESCRIPTION
In Capella, historical_roots has been replaced by historical_summaries, but this was not reflected in our state object.

Fixes #315