### PR TITLE
Update publishBlindedBlockV2 request schema for Deneb

### DIFF
--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -13,7 +13,8 @@ post:
     successful. The beacon node is expected to integrate the new block into its state, and
     therefore validate the block internally, however blocks which fail the validation are still
     broadcast but a different status code is returned (202). Pre-Bellatrix, this endpoint will accept 
-    a `SignedBeaconBlock`. The broadcast behaviour may be adjusted via the `broadcast_validation`
+    a `SignedBeaconBlock`. After Deneb, this additionally instructs the beacon node to broadcast all given
+    signed blobs. The broadcast behaviour may be adjusted via the `broadcast_validation`
     query parameter.
   parameters:
     - name: broadcast_validation
@@ -54,7 +55,7 @@ post:
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBlindedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Capella.SignedBlindedBeaconBlock"
-            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Deneb.SignedBlindedBeaconBlock"
+            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Deneb.SignedBlindedBlockContents"
       application/octet-stream:
         schema:
           description: "SSZ serialized block bytes. Use content type header to indicate that SSZ data is contained in the request body."

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -11,7 +11,8 @@ post:
     The beacon node is also expected to integrate the block into the state, but may broadcast it
     before doing so, so as to aid timely delivery of the block. Should the block fail full
     validation, a separate success response code (202) is used to indicate that the block was
-    successfully broadcast but failed integration. The broadcast behaviour may be adjusted via the
+    successfully broadcast but failed integration. After Deneb, this additionally instructs
+    the beacon node to broadcast all given signed blobs. The broadcast behaviour may be adjusted via the
     `broadcast_validation` query parameter.
   parameters:
     - name: broadcast_validation
@@ -52,7 +53,7 @@ post:
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Altair.SignedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.SignedBeaconBlock"
             - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Capella.SignedBeaconBlock"
-            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Deneb.SignedBeaconBlock"
+            - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Deneb.SignedBlockContents"
       application/octet-stream:
         schema:
           description: "SSZ serialized block bytes. Use content type header to indicate that SSZ data is contained in the request body."


### PR DESCRIPTION
Updated the `publishBlindedBlockV2` to use the `Deneb.SignedBlindedBlockContents` schema for Deneb.

 I think the blob signing endpoints PR #302 was merged right after `publishBlindedBlockV2` was added in #317, and the `publishBlindedBlockV2` method was missing a schema change for Deneb. 