### PR TITLE
Fix typos in getBlobSidecars

### DIFF
--- a/apis/beacon/blob_sidecars/blob_sidecars.yaml
+++ b/apis/beacon/blob_sidecars/blob_sidecars.yaml
@@ -5,7 +5,7 @@ get:
     Retrieves blob sidecars for a given block id.
     Depending on `Accept` header it can be returned either as json or as bytes serialized by SSZ.
 
-    If the `indices` paramneter is specified, only the blob sidecars with the specified indices will be returned. There are no guarantees
+    If the `indices` parameter is specified, only the blob sidecars with the specified indices will be returned. There are no guarantees
     for the returned blob sidecars in terms of ordering.
   tags:
     - Beacon
@@ -16,7 +16,7 @@ get:
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/BlockId'
     - name: indices
       in: query
-      description: Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not speicfied.
+      description: Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.
       required: false
       schema:
         type: array


### PR DESCRIPTION
Just noticed 2 minor typos in `getBlobSidecars`