### PR TITLE
Update validator key/index URI array limits

### DIFF
--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -20,7 +20,7 @@ get:
       required: false
       schema:
         type: array
-        maxItems: 30
+        maxItems: 64
         uniqueItems: true
         items:
           description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -20,7 +20,7 @@ get:
       required: false
       schema:
         type: array
-        maxItems: 30
+        maxItems: 64
         uniqueItems: true
         items:
           description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"


### PR DESCRIPTION
[RFC-7230](https://www.rfc-editor.org/rfc/rfc7230#section-3.1.1) recommends that the Request-Line component of an HTTP 1.1 request is limited to a minimum of 8000 bytes.

Each pubkey is 48 bytes binary, or 96 bytes hex encoded. Prefixing with `0x` adds two more bytes for 98.

All but the first pubkey are preceded by a comma, so with a limit of 64 we will have consumed 64*98+63 bytes, or 6335 bytes.

Factoring the length of these paths (we will assume the `state` is a stateRoot with 0x prefix, ie 66 bytes, to remain adequately pessimistic) we get 107 bytes for `validator_balances` and 99 for `validators`. We increase our consumption by 107 bytes to 6442 bytes.

Adding in some unavoidable bits and pieces from the RFC section on Request-Line-
- `?id=` = 6446
- `GET` = 6449
- `HTTP/1.1` = 6457
- 2 spaces and CR LF = 6461

This leaves us with 1539 bytes to spare.

[Section 5.3.2](https://www.rfc-editor.org/rfc/rfc7230#section-5.3.2) goes on a bit about when the Request-Target may include the absolute URI (ie the hostname), so having a bit of headroom is good if we expect some http clients to respect this rule (which is specifically for proxies, and anecdotally I've never seen it be respected).