### PR TITLE
Use HTTP 414 status code for GET maxItems enforcement

### DIFF
--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -52,7 +52,7 @@ get:
             example:
               code: 400
               message: "Invalid state ID: current"
-    "414"
+    "414":
       description: "Too many validator IDs"
       content:
         application/json:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -52,6 +52,15 @@ get:
             example:
               code: 400
               message: "Invalid state ID: current"
+    "414"
+      description: "Too many validator IDs"
+      content:
+        application/json:
+          schema:
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            example:
+              code: 414
+              message: "Too many validator IDs in request"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -72,5 +72,14 @@ get:
             example:
               code: 404
               message: "State not found"
+    "414"
+      description: "Too many validator IDs"
+      content:
+        application/json:
+          schema:
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            example:
+              code: 414
+              message: "Too many validator IDs in request"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -72,7 +72,7 @@ get:
             example:
               code: 404
               message: "State not found"
-    "414"
+    "414":
       description: "Too many validator IDs"
       content:
         application/json:


### PR DESCRIPTION
I'd like to make the case for why these codes should be implemented-

1. The 400 description doesn't mention maxItems: `Invalid state or validator ID`, so a BN enforcing maxItems will potentially confuse a downstream system.
2. The BN isn't always directly responsible for responding to the downstream system- for example, nginx, cloudflare, haproxy, etc may return a 414 if the Request-Line is too long. Enshrining the 414 code in the spec serves as a signal to programmers of downstream systems that they ought to take care to handle those errors.
3. A client team developing both a VC and a BN may incorrectly assume that because their BN never returns a 414, they do not need to handle a 414 in the VC.