### PR TITLE
Fixed lint warnings

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -18,9 +18,9 @@ get:
       description: Event types to subscribe to
       schema:
         type: array
+        uniqueItems: true
         items:
           type: string
-          uniqueItems: true
           enum:
             - head
             - block

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -36,9 +36,9 @@ post:
         schema:
           title: GetAttesterDutiesBody
           type: array
+          minItems: 1
           items:
             $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-            minItems: 1
   responses:
     "200":
       description: Success response

--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -20,9 +20,9 @@ post:
         schema:
           title: GetSyncCommitteeDutiesBody
           type: array
+          minItems: 1
           items:
             $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-            minItems: 1
   responses:
     "200":
       description: Success response

--- a/apis/validator/liveness.yaml
+++ b/apis/validator/liveness.yaml
@@ -27,9 +27,9 @@ post:
         schema:
           title: PostLivenessRequestBody
           type: array
+          minItems: 1
           items:
             $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-            minItems: 1
   responses:
     "200":
       description: Success response

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -47,9 +47,8 @@ Peer:
     peer_id:
       $ref: "./p2p.yaml#/PeerId"
     enr:
-      allOf:
-        - $ref: "./p2p.yaml#/ENR"
-        - nullable: true
+      nullable: true
+      $ref: "./p2p.yaml#/ENR"
     last_seen_p2p_address:
       allOf:
         - $ref: "./p2p.yaml#/Multiaddr"


### PR DESCRIPTION
These didn't seem to match the warnings raised by @mcdee , but they were valid issues picked up in editor.swagger.io regarding `minItems` and `uniqueItems` needing to be an attribute of an array not an object, an issue with `nullable` usage that we had.