### PR TITLE
Made eth-consensus-version required on new blocks endpoints

### DIFF
--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -43,7 +43,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted, if using SSZ encoding."
+      description: "Version of the block being submitted."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -41,7 +41,7 @@ post:
     - in: header
       schema:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
-      required: false
+      required: true
       name: Eth-Consensus-Version
       description: "Version of the block being submitted, if using SSZ encoding."
   requestBody:

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -39,7 +39,7 @@ post:
     - in: header
       schema:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
-      required: false
+      required: true
       name: Eth-Consensus-Version
       description: "Version of the block being submitted, if using SSZ encoding."
   requestBody:

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -41,7 +41,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted, if using SSZ encoding."
+      description: "Version of the block being submitted."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true


### PR DESCRIPTION
When initially adding eth-consensus-version to interfaces it wasn't able to be required due to backwards compatibility issues.

Given these interfaces are new, we should set it as a required header. This will simplify the determination of whether we're reading a deneb blockContents or a pre-deneb signed block.

Potentially we deprecate the other interface once deneb comes around, but that's up for discussion, and I'm not putting that into this PR, just making this header required for the new interfaces.