### PR TITLE
expand sync committee docs

### DIFF
--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: "getEpochSyncCommittees"
   summary: "Get sync committees for a state."
-  description: "Retrieves the sync committees for the given state."
+  description: "Retrieves the current sync committee for the given state. Also returns the subcommittee assignments."
   tags:
     - Beacon
   parameters:


### PR DESCRIPTION
I wasn't sure what the `validator_aggregates` were in the sync committee endpoint

@michaelsproul confirmed they are the sync subcommittee assignments and I have added this information to the API docs