### PR TITLE
Add block v3 endpoint.

### DIFF
--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -4,6 +4,7 @@ get:
     - Validator
   operationId: "produceBlindedBlock"
   summary: "Produce a new blinded block, without signature."
+  deprecated: true
   description: |
     Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. 
     A blinded block is a block with only a transactions root, rather than a full transactions list.

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -2,11 +2,16 @@ get:
   tags:
     - ValidatorRequiredApi
     - Validator
-  operationId: "produceBlockV2"
+  operationId: "produceBlockV3"
   summary: "Produce a new block, without signature."
-  deprecated: true
   description: |
-    Requests a beacon node to produce a valid block, which can then be signed by a validator.
+    Requests a beacon node to produce a valid block, which can then be signed by a validator. The
+    returned block may be blinded or unblinded, depending on the current state of the network as
+    decided by the execution and beacon nodes.
+
+    The beacon node must return an unblinded block if it obtains the execution payload from its
+    paired execution node. It must only return a blinded block if it obtains the execution payload
+    header from an MEV relay.
 
     Metadata in the response indicates the type of block produced, and the supported types of block
     will be added to as forks progress.
@@ -44,10 +49,14 @@ get:
       headers:
         Eth-Consensus-Version:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+        Eth-Blinded-Payload:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Blinded-Payload'
+        Eth-Payload-Value:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Payload-Value'
       content:
         application/json:
           schema:
-            title: ProduceBlockV2Response
+            title: ProduceBlockV3Response
             type: object
             properties:
               version:
@@ -60,10 +69,12 @@ get:
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Altair.BeaconBlock"
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Bellatrix.BeaconBlock"
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Capella.BeaconBlock"
+                 - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Capella.BlindedBeaconBlock"
                  - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Deneb.BlockContents"
+                 - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Deneb.BlindedBlockContents"
         application/octet-stream:
           schema:
-            description: "SSZ serialized block bytes. Use Accept header to choose this response type, version string is sent in header `Eth-Consensus-Version`."
+            description: "SSZ serialized block or blinded block bytes. Use Accept header to choose this response type, version string is sent in header `Eth-Consensus-Version` and block type in `Eth-Blinded-Payload`."
     "400":
       description: "Invalid block production request"
       content:

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -59,7 +59,7 @@ get:
             title: ProduceBlockV3Response
             type: object
             properties:
-              consensus-version:
+              version:
                 type: string
                 enum: [ phase0, altair, bellatrix, capella, deneb ]
                 example: "phase0"

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -59,10 +59,16 @@ get:
             title: ProduceBlockV3Response
             type: object
             properties:
-              version:
+              consensus-version:
                 type: string
                 enum: [ phase0, altair, bellatrix, capella, deneb ]
                 example: "phase0"
+              blinded-payload:
+                type: boolean
+                example: false
+              payload-value:
+                type: string
+                example: "12345"
               data:
                 oneOf:
                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/BeaconBlock'

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -49,10 +49,10 @@ get:
       headers:
         Eth-Consensus-Version:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-        Eth-Blinded-Payload:
-          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Blinded-Payload'
-        Eth-Payload-Value:
-          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Payload-Value'
+        Eth-Execution-Payload-Blinded:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Blinded'
+        Eth-Execution-Payload-Value:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Value'
       content:
         application/json:
           schema:
@@ -63,10 +63,10 @@ get:
                 type: string
                 enum: [ phase0, altair, bellatrix, capella, deneb ]
                 example: "phase0"
-              blinded-payload:
+              execution-payload-blinded:
                 type: boolean
                 example: false
-              payload-value:
+              execution-payload-value:
                 type: string
                 example: "12345"
               data:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -174,6 +174,8 @@ paths:
     $ref: "./apis/validator/duties/sync.yaml"
   /eth/v2/validator/blocks/{slot}:
     $ref: "./apis/validator/block.v2.yaml"
+  /eth/v3/validator/blocks/{slot}:
+    $ref: "./apis/validator/block.v3.yaml"
   /eth/v1/validator/blinded_blocks/{slot}:
     $ref: "./apis/validator/blinded_block.yaml"
   /eth/v1/validator/attestation_data:
@@ -330,6 +332,7 @@ components:
     Bellatrix.SignedBlindedBeaconBlock:
       $ref: './types/bellatrix/block.yaml#/Bellatrix/SignedBlindedBeaconBlock'
     ConsensusVersion:
+      type: string
       enum: [phase0, altair, bellatrix, capella, deneb]
       example: "phase0"
     SignedValidatorRegistration:
@@ -421,3 +424,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/ConsensusVersion'
+    Eth-Blinded-Payload:
+      description: Required in response so client can deserialize returned json or ssz data to the correct object.
+      required: true
+      schema:
+        type: boolean
+    Eth-Payload-Value:
+      description: Required in response so client can determine relative value of execution payloads.
+      required: true
+      schema:
+        $ref: './types/primitive.yaml#/Wei'

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -424,12 +424,12 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/ConsensusVersion'
-    Eth-Blinded-Payload:
+    Eth-Execution-Payload-Blinded:
       description: Required in response so client can deserialize returned json or ssz data to the correct object.
       required: true
       schema:
         type: boolean
-    Eth-Payload-Value:
+    Eth-Execution-Payload-Value:
       description: Required in response so client can determine relative value of execution payloads.
       required: true
       schema:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -23,6 +23,9 @@ GenesisTime:
     - example: "1590832934"
     - description: "The genesis_time configured for the beacon node, which is the unix time in seconds at which the Eth2.0 chain began."
 
+Wei:
+  $ref: "./primitive.yaml#/Uint256"
+
 Gwei:
   $ref: "./primitive.yaml#/Uint64"
 


### PR DESCRIPTION
As per #309 this adds a version 3 `block` endpoint that consolidates the current blinded and unblinded endpoints.  Features of this endpoint:

- a single endpoint to fetch blocks regardless of type
- allows the beacon node to decide (with help from the EL) if it should use MEV relays for execution payload
- provides the returned block's payload to the proposer
- metadata allows for simpler handling of decoding the returned data