### PR TITLE
Add `inactivity` and `inclusion_delay` fields to Attestation Rewards

### DIFF
--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -61,6 +61,11 @@ AttestationRewards:
           - $ref: "./primitive.yaml#/Uint64"
           - example: 2000
           - description: "attester's inclusion_delay reward in gwei (phase0 only)"
+      inactivity:
+        allOf:
+          - $ref: "./primitive.yaml#/Int64"
+          - example: 2000
+          - description: "attester's inactivity penalty in gwei"
 
 IdealAttestationRewards:
   type: object
@@ -87,6 +92,16 @@ IdealAttestationRewards:
         - $ref: "./primitive.yaml#/Int64"
         - example: 5000
         - description: "Ideal attester's reward for source vote in gwei"
+    inclusion_delay:
+      allOf:
+        - $ref: "./primitive.yaml#/Uint64"
+        - example: 5000
+        - description: "Ideal attester's inclusion_delay reward in gwei (phase0 only)"
+    inactivity:
+      allOf:
+        - $ref: "./primitive.yaml#/Int64"
+        - example: 5000
+        - description: "Ideal attester's inactivity penalty in gwei"
 
 BlockRewards:
   type: object

--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -34,7 +34,7 @@ AttestationsRewards:
 AttestationRewards:
   type: object
   description: "Rewards info for a single attestation"
-  required: ["validator_index", "head", "target", "source"]
+  required: ["validator_index", "head", "target", "source", "inactivity"]
   properties:
       validator_index:
         allOf:
@@ -70,7 +70,7 @@ AttestationRewards:
 IdealAttestationRewards:
   type: object
   description: "Ideal rewards info for a single attestation"
-  required: ["effective_balance", "head", "target", "source"]
+  required: ["effective_balance", "head", "target", "source", "inactivity"]
   properties:
     effective_balance:
       allOf:


### PR DESCRIPTION
This PR adds the following fields to the `AttestationsRewards` response:
1. A `inactivity` field to both `ideal_rewards` and `total_rewards`.
2. A `inclusion_delay` field to `ideal_rewards`

### `inactivity`

Currently the inactivity penalties are not part of the `AttestationsRewards` response, and is something users of this endpoint (e.g. explorers) have expressed interests in. 

I thought about whether it makes sense to combine them into the current `source`, `target` and `head` fields, however I think there are a few reasons to keep them in a separate field:
- The extra penalty for missing attestations or being slashed during an inactivity leak doesn't really belong to any of those fields
- IMO it's more consistent with how they are grouped in the consensus spec ([altair](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#rewards-and-penalties) spec, [phase0](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#get_attestation_deltas) spec). There's also no "cancelling" of rewards from Altair, and inactivity penalties are more separate.

### `ideal_rewards.inclusion_delay`

`inclusion_delay` is part of the individual rewards, but not available under `ideal_rewards`. This would be useful to indicate the ideal `inclusion_delay` reward for each effective balance step.