### PR TITLE
Update syncing status requirements in getHealth

### DIFF
--- a/apis/node/health.yaml
+++ b/apis/node/health.yaml
@@ -11,7 +11,7 @@ get:
       description: "Customize syncing status instead of default status code (206)"
       schema:
         type: integer
-        minimum: 1
+        minimum: 100
         maximum: 599
   responses:
     "200":

--- a/apis/node/health.yaml
+++ b/apis/node/health.yaml
@@ -18,5 +18,7 @@ get:
       description: Node is ready
     "206":
       description: Node is syncing but can serve incomplete data
+    "400":
+      description: Invalid syncing status code
     "503":
       description: Node not initialized or having issues


### PR DESCRIPTION
While implementing `syncing_status` query parameter (https://github.com/ethereum/beacon-APIs/pull/251), I noticed two issues with the current spec

1. Schema allows invalid http status codes (1-99), this will cause problems for most http servers
2. The API accepts user provided values but there is no error response for invalid values
