### PR TITLE
Fix casing of JSON metadata.

### DIFF
--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -63,10 +63,10 @@ get:
                 type: string
                 enum: [ phase0, altair, bellatrix, capella, deneb ]
                 example: "phase0"
-              execution-payload-blinded:
+              execution_payload_blinded:
                 type: boolean
                 example: false
-              execution-payload-value:
+              execution_payload_value:
                 type: string
                 example: "12345"
               data:


### PR DESCRIPTION
Casing of the JSON metadata for the v3 block API was in kebab case (as per headers) but should be in camel case as per all other JSON.