### PR TITLE
blocksv3: add consensus value

### DIFF
--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -53,6 +53,8 @@ get:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Blinded'
         Eth-Execution-Payload-Value:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Value'
+        Eth-Consensus-Payload-Value:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Payload-Value'
       content:
         application/json:
           schema:
@@ -67,6 +69,9 @@ get:
                 type: boolean
                 example: false
               execution_payload_value:
+                type: string
+                example: "12345"
+              consensus_payload_value:
                 type: string
                 example: "12345"
               data:

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -53,8 +53,8 @@ get:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Blinded'
         Eth-Execution-Payload-Value:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Value'
-        Eth-Consensus-Payload-Value:
-          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Payload-Value'
+        Eth-Consensus-Block-Value:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Block-Value'
       content:
         application/json:
           schema:
@@ -71,7 +71,7 @@ get:
               execution_payload_value:
                 type: string
                 example: "12345"
-              consensus_payload_value:
+              consensus_block_value:
                 type: string
                 example: "12345"
               data:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -434,8 +434,8 @@ components:
       required: true
       schema:
         $ref: './types/primitive.yaml#/Wei'
-    Eth-Consensus-Payload-Value:
-      description: Required in response so client can determine relative value of consensus payloads.
+    Eth-Consensus-Block-Value:
+      description: Required in response so client can determine relative value of consensus blocks.
       required: true
       schema:
         $ref: './types/primitive.yaml#/Wei'

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -434,3 +434,8 @@ components:
       required: true
       schema:
         $ref: './types/primitive.yaml#/Wei'
+    Eth-Consensus-Payload-Value:
+      description: Required in response so client can determine relative value of consensus payloads.
+      required: true
+      schema:
+        $ref: './types/primitive.yaml#/Wei'


### PR DESCRIPTION
In order to compare blocks coming from two sources, a validator client must consider both consensus and execution profit - without consensus reward information, the VC must fall back on unreliable heuristics that can be biased towards inefficient consensus packing, specially when execution payloads are the same which they are likely to be if the block producer is using the same mev relay for both beacon nodes.

The consensus computation is currently not a necessary part of block construction but given that blocks are constructed over a state, the information necessary to compute the is already present at block construction time.

This PR suggests a mandatory value to make validator client multiplexing easier at the expense of beacon node complexity - if instead it is optional, we are back to where we started where blocks cannot be compared across implementations.

The value has to be trusted, ie the BN could be report an inaccurate value but this is not a new risk.