### PR TITLE
update selections endpoint description

### DIFF
--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -5,9 +5,10 @@ post:
     This endpoint should be used by a validator client running as part of a distributed validator cluster, and is 
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
-    to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
-    Validator clients must query this endpoint at the start of an epoch for all validators that have attester duties 
-    in that epoch. Consensus clients need not support this endpoint and may return a 501.
+    to correctly determine if any of its validators has been selected to perform an attestation aggregation duty in a slot. 
+    Validator clients must query this endpoint at the start of an epoch for the current and lookahead (next) epochs for
+    all validators that have attester duties in the current and lookahead epochs. Consensus clients need not support this
+    endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -6,7 +6,7 @@ post:
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
     to correctly determine if any of its validators has been selected to perform an attestation aggregation duty in a slot. 
-    Validator clients must query this endpoint at the start of an epoch for the current and lookahead (next) epochs for
+    Validator clients running in a distributed validator cluster must query this endpoint at the start of an epoch for the current and lookahead (next) epochs for
     all validators that have attester duties in the current and lookahead epochs. Consensus clients need not support this
     endpoint and may return a 501.
   tags:

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -5,8 +5,9 @@ post:
     This endpoint should be used by a validator client running as part of a distributed validator cluster, and is 
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
-    to correctly determine if one of its validators has been selected to perform an aggregation duty in this slot. 
-    Consensus clients need not support this endpoint and may return a 501.
+    to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
+    Validator clients must query this endpoint at the start of an epoch for all validators that have attester duties 
+    in that epoch. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -7,7 +7,7 @@ post:
     validator cluster, and is implemented by a distributed validator middleware client. This endpoint is 
     used to exchange partial selection proofs (slot signatures) for combined/aggregated selection proofs to 
     allow a validator client to correctly determine if any of its validators has been selected to perform a 
-    sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
+    sync committee contribution (sync aggregation) duty in a slot. Validator clients running in a distributed validator cluster must query this endpoint
     at the start of each slot for all validators that are included in the current sync committee. Consensus
     clients need not support this endpoint and may return a 501.
   tags:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -5,11 +5,11 @@ post:
     Submit sync committee selections to a DVT middleware client. It returns the threshold aggregated sync 
     committee selection. This endpoint should be used by a validator client running as part of a distributed 
     validator cluster, and is implemented by a distributed validator middleware client. This endpoint is 
-    used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
-    allow a validator client to correctly determine if one of its validators has been selected to perform a 
+    used to exchange partial selection proofs (slot signatures) for combined/aggregated selection proofs to 
+    allow a validator client to correctly determine if any of its validators has been selected to perform a 
     sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
-    at the start of an epoch for all validators that have sync committee contribution duties in that epoch. 
-    Consensus clients need not support this endpoint and may return a 501.
+    at the start of each slot for all validators that are included in the current sync committee. Consensus
+    clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -6,9 +6,10 @@ post:
     committee selection. This endpoint should be used by a validator client running as part of a distributed 
     validator cluster, and is implemented by a distributed validator middleware client. This endpoint is 
     used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
-    allow a validator client to correctly determine if one of its validators has been selected to perform 
-    a sync committee contribution (sync aggregation) duty in this slot. Consensus clients need not support 
-    this endpoint and may return a 501.
+    allow a validator client to correctly determine if one of its validators has been selected to perform a 
+    sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
+    at the start of an epoch for all validators that have sync committee contribution duties in that epoch. 
+    Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:


### PR DESCRIPTION
Update endpoint descriptions for the following selections endpoints:
* `/eth/v1/validator/beacon_committee_selections`
* `/eth/v1/validator/sync_committee_selections`

This PR updates selection endpoint descriptions to explicitly state when to call these endpoints:
- For sync committee selections, validator clients must query this endpoint at the start of each slot in the sync committee period.
- For beacon committee selections, validator clients must query this endpoint at the start of each epoch for attester duties in the current and next epochs.

Note: This change eliminates confusion among client teams implementing these endpoints on when to query the selection endpoints.