### PR TITLE
Update Deneb for `v1.4.0-beta.4`

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -379,12 +379,8 @@ components:
       $ref: './types/primitive.yaml#/Blob'
     Deneb.BlobSidecars:
       $ref: './types/deneb/blob_sidecar.yaml#/Deneb/BlobSidecars'
-    Deneb.SignedBlobSidecar:
-      $ref: './types/deneb/blob_sidecar.yaml#/Deneb/SignedBlobSidecar'
     Deneb.BlindedBlobSidecar:
       $ref: './types/deneb/blob_sidecar.yaml#/Deneb/BlindedBlobSidecar'
-    Deneb.SignedBlindedBlobSidecar:
-      $ref: './types/deneb/blob_sidecar.yaml#/Deneb/SignedBlindedBlobSidecar'
     Node:
       $ref: './types/fork_choice.yaml#/Node'
     ExtraData:

--- a/types/deneb/blob_sidecar.yaml
+++ b/types/deneb/blob_sidecar.yaml
@@ -7,14 +7,20 @@ Deneb:
         type: array
         items:
           $ref: '../primitive.yaml#/Blob'
+        minItems: 0
+        maxItems: 4096
       kzg_commitments:
         type: array
         items:
           $ref: '../primitive.yaml#/KZGCommitment'
+        minItems: 0
+        maxItems: 4096
       kzg_proofs:
         type: array
         items:
           $ref: '../primitive.yaml#/KZGProof'
+        minItems: 0
+        maxItems: 4096
 
   BlobSidecars:
     type: array

--- a/types/deneb/blob_sidecar.yaml
+++ b/types/deneb/blob_sidecar.yaml
@@ -1,4 +1,21 @@
 Deneb:
+  BlobsBundle:
+    type: object
+    description: "A blbs bundle as defined in the Deneb consensus spec."
+    properties:
+      blobs:
+        type: array
+        items:
+          $ref: '../primitive.yaml#/Blob'
+      kzg_commitments:
+        type: array
+        items:
+          $ref: '../primitive.yaml#/KZGCommitment'
+      kzg_proofs:
+        type: array
+        items:
+          $ref: '../primitive.yaml#/KZGProof'
+
   BlobSidecars:
     type: array
     items:

--- a/types/deneb/blob_sidecar.yaml
+++ b/types/deneb/blob_sidecar.yaml
@@ -6,19 +6,19 @@ Deneb:
     minItems: 0
     maxItems: 6
 
+  KzgCommitmentInclusionProof:
+    type: array
+    items:
+      $ref: '../primitive.yaml#/Root'
+      description: "Merkle proof consisting of [`KZG_COMMITMENT_INCLUSION_PROOF_DEPTH`](https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#preset) roots"
+    minItems: 17
+    maxItems: 17
+
   BlobSidecar:
     type: object
     description: "A blob sidecar as defined in the Deneb consensus spec."
     properties:
-      block_root:
-        $ref: "../primitive.yaml#/Root"
       index:
-        $ref: "../primitive.yaml#/Uint64"
-      slot:
-        $ref: "../primitive.yaml#/Uint64"
-      block_parent_root:
-        $ref: "../primitive.yaml#/Root"
-      proposer_index:
         $ref: "../primitive.yaml#/Uint64"
       blob:
         $ref: "../primitive.yaml#/Blob"
@@ -26,22 +26,10 @@ Deneb:
         $ref: '../primitive.yaml#/KZGCommitment'
       kzg_proof:
         $ref: '../primitive.yaml#/KZGProof'
-
-  SignedBlobSidecars:
-    type: array
-    items:
-      $ref: '#/Deneb/SignedBlobSidecar'
-    minItems: 0
-    maxItems: 6
-
-  SignedBlobSidecar:
-    type: object
-    description: "The `SignedBlobSidecar` object envelope from the CL Deneb spec."
-    properties:
-      message:
-        $ref: "#/Deneb/BlobSidecar"
-      signature:
-        $ref: "../primitive.yaml#/Signature"
+      signed_block_header:
+        $ref: '../block.yaml#/SignedBeaconBlockHeader'
+      kzg_commitment_inclusion_proof:
+        $ref: '#/Deneb/KzgCommitmentInclusionProof'
 
   BlindedBlobSidecars:
     type: array
@@ -70,19 +58,3 @@ Deneb:
         $ref: '../primitive.yaml#/KZGCommitment'
       kzg_proof:
         $ref: '../primitive.yaml#/KZGProof'
-
-  SignedBlindedBlobSidecars:
-    type: array
-    items:
-      $ref: '#/Deneb/SignedBlindedBlobSidecar'
-    minItems: 0
-    maxItems: 6
-
-  SignedBlindedBlobSidecar:
-    type: object
-    description: "A variant of the `SignedBlobSidecar` object envelope from the CL Deneb spec, which contains a `BlindedBlobSidecar` rather than a `BlobSidecar`."
-    properties:
-      message:
-        $ref: "#/Deneb/BlindedBlobSidecar"
-      signature:
-        $ref: "../primitive.yaml#/Signature"

--- a/types/deneb/block_contents.yaml
+++ b/types/deneb/block_contents.yaml
@@ -5,8 +5,8 @@ Deneb:
     properties:
       block:
         $ref: "./block.yaml#/Deneb/BeaconBlock"
-      blob_sidecars:
-        $ref: "./blob_sidecar.yaml#/Deneb/BlobSidecars"
+      blobs_bundle:
+        $ref: "./blob_sidecar.yaml#/Deneb/BlobsBundle"
 
   BlindedBlockContents:
     type: object

--- a/types/deneb/block_contents.yaml
+++ b/types/deneb/block_contents.yaml
@@ -23,8 +23,8 @@ Deneb:
     properties:
       signed_block:
         $ref: "./block.yaml#/Deneb/SignedBeaconBlock"
-      signed_blob_sidecars:
-        $ref: "./blob_sidecar.yaml#/Deneb/SignedBlobSidecars"
+      blob_sidecars:
+        $ref: "./blob_sidecar.yaml#/Deneb/BlobSidecars"
 
   SignedBlindedBlockContents:
     type: object
@@ -32,6 +32,5 @@ Deneb:
     properties:
       signed_blinded_block:
         $ref: "./block.yaml#/Deneb/SignedBlindedBeaconBlock"
-      signed_blinded_blob_sidecars:
-        $ref: "./blob_sidecar.yaml#/Deneb/SignedBlindedBlobSidecars"
-       
+      blinded_blob_sidecars:
+        $ref: "./blob_sidecar.yaml#/Deneb/BlindedBlobSidecars"


### PR DESCRIPTION
`BlobSidecar` are no longer signed, but instead are linked with the signed block via merkle proof. Also renamed `signed_blob_sidecars` and `signed_blinded_blob_sidecars` in `BlockContents` envelopes to match the new types (without signature).

- https://github.com/ethereum/consensus-specs/pull/3531