### PR TITLE
Change Deneb description for publishBlock(V2)

### DIFF
--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -12,7 +12,7 @@ post:
     before doing so, so as to aid timely delivery of the block. Should the block fail full
     validation, a separate success response code (202) is used to indicate that the block was
     successfully broadcast but failed integration. After Deneb, this additionally instructs
-    the beacon node to broadcast all given signed blobs. The broadcast behaviour may be adjusted via the
+    the beacon node to broadcast all given kzg proofs and blobs. The broadcast behaviour may be adjusted via the
     `broadcast_validation` query parameter.
   parameters:
     - name: broadcast_validation

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -12,7 +12,7 @@ post:
     before doing so, so as to aid timely delivery of the block. Should the block fail full
     validation, a separate success response code (202) is used to indicate that the block was
     successfully broadcast but failed integration. After Deneb, this additionally instructs
-    the beacon node to broadcast all given signed blobs.
+    the beacon node to broadcast all given kzg proofs and blobs.
   parameters:
     - in: header
       schema:


### PR DESCRIPTION
We now broadcast kzg proofs and blobs as received by the BN, no signing by VC.