### PR TITLE
Clarify broadcast validation failure in response code for publishBlockV2

### DIFF
--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -64,7 +64,7 @@ post:
     "202":
       description: "The block failed validation, but was successfully broadcast anyway. It was not integrated into the beacon node's database."
     "400":
-      description: "The `SignedBlindedBeaconBlock` object is invalid"
+      description: "The `SignedBlindedBeaconBlock` object is invalid or broadcast validation failed"
       content:
         application/json:
           schema:

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -63,7 +63,7 @@ post:
     "202":
       description: "The block could not be integrated into the beacon node's database as it failed validation, but was successfully broadcast."
     "400":
-      description: "The `SignedBeaconBlock` object is invalid and could not be broadcast"
+      description: "The `SignedBeaconBlock` object is invalid or broadcast validation failed"
       content:
         application/json:
           schema:


### PR DESCRIPTION
It's mentioned in description that in case of broadcast validation failure we should return 400, but error codes description like "The `SignedBlindedBeaconBlock` object is invalid" confuses a bit. I've changed it to be more clear