### PR TITLE
Make getPeersV1 meta element optional

### DIFF
--- a/apis/node/peers.yaml
+++ b/apis/node/peers.yaml
@@ -36,6 +36,7 @@ get:
                   $ref: "../../beacon-node-oapi.yaml#/components/schemas/Peer"
               meta:
                 type: object
+                required: false
                 properties:
                   count:
                     description: "Total number of items"

--- a/apis/node/peers.yaml
+++ b/apis/node/peers.yaml
@@ -29,6 +29,7 @@ get:
           schema:
             title: GetPeersResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array
@@ -36,7 +37,6 @@ get:
                   $ref: "../../beacon-node-oapi.yaml#/components/schemas/Peer"
               meta:
                 type: object
-                required: false
                 properties:
                   count:
                     description: "Total number of items"


### PR DESCRIPTION
No one likes the meta element, but there's no appetite either for the effort to remove it 

- See discussion in https://github.com/ethereum/beacon-APIs/pull/384#issuecomment-1850805471

According to @mcdee review of clients seems that support of the meta element is poor. If no-one has complained should mean that no consumer is dependent on it.

To address this one-off oddity we could do a breaking change on route v1 and mark the meta property as optional. Then only Nimbus needs to fix the route to be compliant, which @arnetheduck is already keen on doing.

Closes https://github.com/ethereum/beacon-APIs/issues/366