### PR TITLE
fix: add missing type property

### DIFF
--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -112,6 +112,7 @@ Aggregate:
 
 
 SignedAggregateAndProof:
+  type: object
   description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#signedaggregateandproof) object"
   properties:
     message:


### PR DESCRIPTION
The missing `type: object` prevents generated JSON to be valid.