### PR TITLE
Fix broken link in deployed doc

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,6 +46,7 @@ jobs:
           cp -r dist ./deploy
           cp -r assets ./deploy
           cp index.html ./deploy
+          cp validator-flow.md ./deploy
       - name: Restore releases
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The [Checkout validator flow](https://ethereum.github.io/beacon-APIs/validator-flow.md) link is broken on the deployed [doc](https://ethereum.github.io/beacon-APIs/#/).
This is due to a file not being copied to the right folder during the deployment phase.

Note that this will only impact the deploy procedure. The right file should be copied on the `gh-pages` branch to fix on the live website.