### PR TITLE
Use ERC-55 mixed-case checksum address encoding for execution address

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -79,7 +79,7 @@ get:
               description: The node has received a BLS to execution change (from P2P or API)
               value: |
                 event: bls_to_execution_change
-                data: {"message":{"validator_index":"1", "from_bls_pubkey":"0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95", "to_execution_address":"0x9be8d619c56699667c1fedcd15f6b14d8B067f72"}, "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}
+                data: {"message":{"validator_index":"1", "from_bls_pubkey":"0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95", "to_execution_address":"0x9Be8d619c56699667c1feDCD15f6b14D8B067F72"}, "signature":"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}
             finalized_checkpoint:
               description: Finalized checkpoint has been updated
               value: |

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -103,7 +103,7 @@ ExecutionAddress:
   type: string
   format: hex
   description: "An address on the execution (Ethereum 1) network."
-  example: "0xabcf8e0d4e9587369b2301d0790347320302cc09"
+  example: "0xAbcF8e0d4e9587369b2301D0790347320302cc09"
   pattern: "^0x[a-fA-F0-9]{40}$"
 
 Transaction:


### PR DESCRIPTION
Based on discussion in https://github.com/ethereum/beacon-APIs/pull/395 it would be good if we could use  [ERC-55 mixed-case checksum address encoding](https://github.com/ethereum/ercs/blob/master/ERCS/erc-55.md) for execution addresses in beacon API spec.


If this gets merged we should also do the same to keymanager API spec ([types/eth_address.yaml#L2](https://github.com/ethereum/keymanager-APIs/blob/a8c45a15cf820a1a832eafaec1c64ea31ed6f2ca/types/eth_address.yaml#L2)). Builder API spec references [SignedValidatorRegistration](https://github.com/ethereum/builder-specs/blob/22a17d312bdd18aba59aaa536002553759a55c16/builder-oapi.yaml#L78-L79) from beacon API spec so we should be fine there (some example values could be updated)
