### PR TITLE
Add required field to object and request body definitions

### DIFF
--- a/apis/beacon/blob_sidecars/blob_sidecars.yaml
+++ b/apis/beacon/blob_sidecars/blob_sidecars.yaml
@@ -31,6 +31,7 @@ get:
           schema:
             title: GetBlobSidecarsResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Deneb.BlobSidecars"

--- a/apis/beacon/blocks/attestations.yaml
+++ b/apis/beacon/blocks/attestations.yaml
@@ -18,6 +18,7 @@ get:
           schema:
             title: GetBlockAttestationsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/blocks/blinded_block.yaml
+++ b/apis/beacon/blocks/blinded_block.yaml
@@ -22,6 +22,7 @@ get:
           schema:
             title: GetBlindedBlockResponse
             type: object
+            required: [version, execution_optimistic, finalized, data]
             properties:
               version:
                 type: string

--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -22,6 +22,7 @@ get:
           schema:
             title: GetBlockV2Response
             type: object
+            required: [version, execution_optimistic, finalized, data]
             properties:
               version:
                 type: string

--- a/apis/beacon/blocks/block.yaml
+++ b/apis/beacon/blocks/block.yaml
@@ -26,6 +26,7 @@ get:
           schema:
             title: GetBlockResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/SignedBeaconBlock"

--- a/apis/beacon/blocks/header.yaml
+++ b/apis/beacon/blocks/header.yaml
@@ -17,6 +17,7 @@ get:
           schema:
             title: GetBlockHeaderResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -24,6 +25,7 @@ get:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
+                required: [root, canonical, header]
                 properties:
                   root:
                     $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"

--- a/apis/beacon/blocks/headers.yaml
+++ b/apis/beacon/blocks/headers.yaml
@@ -28,6 +28,7 @@ get:
           schema:
             title: GetBlockHeadersResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -37,6 +38,7 @@ get:
                 type: array
                 items:
                   type: object
+                  required: [root, canonical, header]
                   properties:
                     root:
                       $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"

--- a/apis/beacon/blocks/root.yaml
+++ b/apis/beacon/blocks/root.yaml
@@ -23,6 +23,7 @@ get:
           schema:
             type: object
             title: GetBlockRootResponse
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -30,6 +31,7 @@ get:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
+                required: [root]
                 properties:
                   root:
                     allOf:

--- a/apis/beacon/deposit_snapshot.yaml
+++ b/apis/beacon/deposit_snapshot.yaml
@@ -14,6 +14,7 @@
             schema:
               type: object
               title: GetDepositSnapshotResponse
+              required: [data]
               properties:
                 data:
                   $ref: '../../beacon-node-oapi.yaml#/components/schemas/DepositSnapshotResponse'

--- a/apis/beacon/genesis.yaml
+++ b/apis/beacon/genesis.yaml
@@ -13,9 +13,11 @@
             schema:
               type: object
               title: GetGenesisResponse
+              required: [data]
               properties:
                 data:
                   type: object
+                  required: [genesis_time, genesis_validators_root, genesis_fork_version]
                   properties:
                     genesis_time:
                       $ref: '../../beacon-node-oapi.yaml#/components/schemas/GenesisTime'

--- a/apis/beacon/light_client/bootstrap.yaml
+++ b/apis/beacon/light_client/bootstrap.yaml
@@ -24,6 +24,7 @@ get:
           schema:
             title: GetLightClientBootstrapResponse
             type: object
+            required: [version, data]
             properties:
               version:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'

--- a/apis/beacon/light_client/finality_update.yaml
+++ b/apis/beacon/light_client/finality_update.yaml
@@ -19,6 +19,7 @@ get:
           schema:
             title: GetLightClientFinalityUpdateResponse
             type: object
+            required: [version, data]
             properties:
               version:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'

--- a/apis/beacon/light_client/optimistic_update.yaml
+++ b/apis/beacon/light_client/optimistic_update.yaml
@@ -19,6 +19,7 @@ get:
           schema:
             title: GetLightClientOptimisticUpdateResponse
             type: object
+            required: [version, data]
             properties:
               version:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'

--- a/apis/beacon/light_client/updates.yaml
+++ b/apis/beacon/light_client/updates.yaml
@@ -29,6 +29,7 @@ get:
             type: array
             items:
               type: object
+              required: [version, data]
               properties:
                 version:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'

--- a/apis/beacon/pool/attestations.yaml
+++ b/apis/beacon/pool/attestations.yaml
@@ -23,6 +23,7 @@ get:
           schema:
             title: GetPoolAttestationsResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/beacon/pool/attester_slashings.yaml
+++ b/apis/beacon/pool/attester_slashings.yaml
@@ -12,6 +12,7 @@ get:
           schema:
             title: GetPoolAttesterSlashingsResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/beacon/pool/bls_to_execution_changes.yaml
+++ b/apis/beacon/pool/bls_to_execution_changes.yaml
@@ -12,6 +12,7 @@ get:
           schema:
             title: GetPoolBLSToExecutionChangesResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/beacon/pool/proposer_slashings.yaml
+++ b/apis/beacon/pool/proposer_slashings.yaml
@@ -12,6 +12,7 @@ get:
           schema:
             title: GetPoolProposerSlashingsResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/beacon/pool/voluntary_exists.yaml
+++ b/apis/beacon/pool/voluntary_exists.yaml
@@ -12,6 +12,7 @@ get:
           schema:
             title: GetPoolVoluntaryExitsResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/beacon/rewards/attestations.yaml
+++ b/apis/beacon/rewards/attestations.yaml
@@ -32,6 +32,7 @@ post:
           schema:
             title: GetAttestationsRewardsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/rewards/blocks.yaml
+++ b/apis/beacon/rewards/blocks.yaml
@@ -19,6 +19,7 @@ get:
           schema:
             title: GetBlockRewardsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/rewards/sync_committee.yaml
+++ b/apis/beacon/rewards/sync_committee.yaml
@@ -31,6 +31,7 @@ post:
           schema:
             title: GetSyncCommitteeRewardsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -41,6 +41,7 @@ get:
           schema:
             title: GetEpochCommitteesResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/states/finality_checkpoints.yaml
+++ b/apis/beacon/states/finality_checkpoints.yaml
@@ -18,6 +18,7 @@ get:
           schema:
             title: GetStateFinalityCheckpointsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -25,6 +26,7 @@ get:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
+                required: [previous_justified, current_justified, finalized]
                 properties:
                   previous_justified:
                     $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Checkpoint'

--- a/apis/beacon/states/fork.yaml
+++ b/apis/beacon/states/fork.yaml
@@ -17,6 +17,7 @@ get:
           schema:
             title: GetStateForkResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/states/randao.yaml
+++ b/apis/beacon/states/randao.yaml
@@ -32,6 +32,7 @@ get:
           schema:
             title: GetStateRandaoResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -39,6 +40,7 @@ get:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
+                required: [randao]
                 properties:
                   randao:
                     allOf:

--- a/apis/beacon/states/root.yaml
+++ b/apis/beacon/states/root.yaml
@@ -16,6 +16,7 @@ get:
           schema:
             title: GetStateRootResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -23,6 +24,7 @@ get:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 type: object
+                required: [root]
                 properties:
                   root:
                     allOf:

--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -25,6 +25,7 @@ get:
           schema:
             title: GetEpochSyncCommitteesResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/states/validator.yaml
+++ b/apis/beacon/states/validator.yaml
@@ -24,6 +24,7 @@ get:
           schema:
             title: GetStateValidatorResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -34,6 +34,7 @@ get:
           schema:
             title: GetStateValidatorBalancesResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -107,6 +108,7 @@ post:
           schema:
             title: GetStateValidatorBalancesResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -45,6 +45,7 @@ get:
           schema:
             title: GetStateValidatorsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
@@ -132,6 +133,7 @@ post:
           schema:
             title: GetStateValidatorsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/builder/states/expected_withdrawals.yaml
+++ b/apis/builder/states/expected_withdrawals.yaml
@@ -25,6 +25,7 @@ get:
           schema:
             title: GetNextWithdrawalsResponse
             type: object
+            required: [execution_optimistic, finalized, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/config/deposit_contract.yaml
+++ b/apis/config/deposit_contract.yaml
@@ -12,9 +12,11 @@ get:
           schema:
             title: GetDepositContractResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: object
+                required: [chain_id, address]
                 properties:
                   chain_id:
                     allOf:

--- a/apis/config/fork_schedule.yaml
+++ b/apis/config/fork_schedule.yaml
@@ -12,6 +12,7 @@ get:
           schema:
             title: GetForkScheduleResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -21,6 +21,7 @@ get:
           schema:
             title: GetSpecResponse
             type: object
+            required: [data]
             properties:
               data:
                 description: |

--- a/apis/debug/heads.v2.yaml
+++ b/apis/debug/heads.v2.yaml
@@ -12,11 +12,13 @@ get:
           schema:
             title: GetDebugChainHeadsResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array
                 items:
                   type: object
+                  required: [root, slot, execution_optimistic]
                   properties:
                     root:
                       $ref: "../../beacon-node-oapi.yaml#/components/schemas/Root"

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -22,6 +22,7 @@ get:
           schema:
             title: GetStateV2Response
             type: object
+            required: [version, execution_optimistic, finalized, data]
             properties:
               version:
                 type: string

--- a/apis/node/identity.yaml
+++ b/apis/node/identity.yaml
@@ -12,6 +12,7 @@ get:
           schema:
             title: GetNetworkIdentityResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: "../../beacon-node-oapi.yaml#/components/schemas/NetworkIdentity"

--- a/apis/node/peer.yaml
+++ b/apis/node/peer.yaml
@@ -18,6 +18,7 @@ get:
           schema:
             title: GetPeerResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Peer'

--- a/apis/node/peer_count.yaml
+++ b/apis/node/peer_count.yaml
@@ -12,9 +12,11 @@ get:
           schema:
             title: GetPeerCountResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: object
+                required: [disconnected, connecting, connected, disconnecting]
                 properties: 
                   disconnected:
                     allOf:

--- a/apis/node/peers.yaml
+++ b/apis/node/peers.yaml
@@ -29,6 +29,7 @@ get:
           schema:
             title: GetPeersResponse
             type: object
+            required: [data, meta]
             properties:
               data:
                 type: array
@@ -36,6 +37,7 @@ get:
                   $ref: "../../beacon-node-oapi.yaml#/components/schemas/Peer"
               meta:
                 type: object
+                required: [count]
                 properties:
                   count:
                     description: "Total number of items"

--- a/apis/node/syncing.yaml
+++ b/apis/node/syncing.yaml
@@ -13,9 +13,11 @@
             schema:
               title: GetSyncingStatusResponse
               type: object
+              required: [data]
               properties:
                 data:
                   type: object
+                  required: [head_slot, sync_distance, is_syncing, is_optimistic, el_offline]
                   properties:
                     head_slot:
                       allOf:

--- a/apis/node/version.yaml
+++ b/apis/node/version.yaml
@@ -12,9 +12,11 @@ get:
           schema:
             title: GetVersionResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: object
+                required: [version]
                 properties:
                   version:
                     $ref: '../../beacon-node-oapi.yaml#/components/schemas/Version'

--- a/apis/validator/aggregate_and_proofs.yaml
+++ b/apis/validator/aggregate_and_proofs.yaml
@@ -6,6 +6,7 @@ post:
     - ValidatorRequiredApi
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/aggregate_attestation.yaml
+++ b/apis/validator/aggregate_attestation.yaml
@@ -33,6 +33,7 @@ get:
           schema:
             title: GetAggregatedAttestationResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Attestation'

--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -31,6 +31,7 @@ get:
           schema:
             title: ProduceAttestationDataResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/AttestationData'

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -12,6 +12,7 @@ post:
   tags:
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -29,6 +29,7 @@ post:
           schema:
             title: BeaconCommitteeSelectionResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -12,6 +12,7 @@ post:
     - ValidatorRequiredApi
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -19,6 +19,7 @@ post:
           type: array
           items:
             type: object
+            required: [validator_index, committee_index, committees_at_slot, slot, is_aggregator]
             properties:
               validator_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'

--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -52,6 +52,7 @@ get:
           schema:
             title: ProduceBlindedBlockResponse
             type: object
+            required: [version, data]
             properties:
               version:
                 type: string

--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -49,6 +49,7 @@ get:
           schema:
             title: ProduceBlockV2Response
             type: object
+            required: [version, data]
             properties:
               version:
                 type: string

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -93,6 +93,7 @@ get:
           schema:
             title: ProduceBlockV3Response
             type: object
+            required: [version, execution_payload_blinded, execution_payload_value, consensus_block_value, data]
             properties:
               version:
                 type: string

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -47,6 +47,7 @@ post:
           schema:
             title: GetAttesterDutiesResponse
             type: object
+            required: [dependent_root, execution_optimistic, data]
             properties:
               dependent_root:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/DependentRoot"

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -31,6 +31,7 @@ get:
           schema:
             title: GetProposerDutiesResponse
             type: object
+            required: [dependent_root, execution_optimistic, data]
             properties:
               dependent_root:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/DependentRoot"

--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -31,6 +31,7 @@ post:
           schema:
             title: GetSyncCommitteeDutiesResponse
             type: object
+            required: [execution_optimistic, data]
             properties:
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/validator/liveness.yaml
+++ b/apis/validator/liveness.yaml
@@ -38,11 +38,13 @@ post:
           schema:
             title: PostLivenessResponseBody
             type: object
+            required: [data]
             properties:
               data:
                 type: array
                 items:
                   type: object
+                  required: [index, is_live]
                   properties:
                     index:
                       $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -27,6 +27,7 @@ post:
           type: array
           items:
             type: object
+            required: [validator_index, fee_recipient]
             properties:
               validator_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'

--- a/apis/validator/prepare_beacon_proposer.yaml
+++ b/apis/validator/prepare_beacon_proposer.yaml
@@ -21,6 +21,7 @@ post:
     - ValidatorRequiredApi
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -15,6 +15,7 @@ post:
   tags:
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/sync_committee_contribution.yaml
+++ b/apis/validator/sync_committee_contribution.yaml
@@ -37,6 +37,7 @@ get:
           schema:
             title: produceSyncCommitteeContributionResponse
             type: object
+            required: [data]
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncCommitteeContribution'

--- a/apis/validator/sync_committee_contribution_and_proof.yaml
+++ b/apis/validator/sync_committee_contribution_and_proof.yaml
@@ -6,6 +6,7 @@ post:
     - ValidatorRequiredApi
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -13,6 +13,7 @@ post:
   tags:
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -29,6 +29,7 @@ post:
           schema:
             title: SyncCommitteeSelectionResponse
             type: object
+            required: [data]
             properties:
               data:
                 type: array

--- a/apis/validator/sync_committee_subscriptions.yaml
+++ b/apis/validator/sync_committee_subscriptions.yaml
@@ -12,6 +12,7 @@ post:
     - ValidatorRequiredApi
     - Validator
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -2,6 +2,7 @@ Altair:
   BeaconBlockCommon:
     # An abstract object to collect the common fields between the BeaconBlockHeader and the BeaconBlock objects
     type: object
+    required: [slot, proposer_index, parent_root, state_root]
     properties:
       slot:
         allOf:
@@ -23,6 +24,7 @@ Altair:
   BeaconBlockBody:
     type: object
     description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#beaconblockbody) object from the CL Altair spec."
+    required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate]
     properties:
       randao_reveal:
         allOf:
@@ -60,6 +62,7 @@ Altair:
     allOf:
       - $ref: '#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Altair/BeaconBlockBody'
@@ -67,6 +70,7 @@ Altair:
   SignedBeaconBlock:
     type: object
     description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Altair spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Altair/BeaconBlock"

--- a/types/altair/light_client.yaml
+++ b/types/altair/light_client.yaml
@@ -23,12 +23,14 @@ Altair:
 
   LightClientHeader:
     type: object
+    required: [beacon]
     properties:
       beacon:
         $ref: '../block.yaml#/BeaconBlockHeader'
 
   LightClientBootstrap:
     type: object
+    required: [header, current_sync_committee, current_sync_committee_branch]
     properties:
       header:
         $ref: '#/Altair/LightClientHeader'
@@ -38,6 +40,7 @@ Altair:
         $ref: '#/Altair/CurrentSyncCommitteeBranch'
   LightClientUpdate:
     type: object
+    required: [attested_header, next_sync_committee, next_sync_committee_branch, finalized_header, finality_branch, sync_aggregate, signature_slot]
     properties:
       attested_header:
         $ref: '#/Altair/LightClientHeader'
@@ -55,6 +58,7 @@ Altair:
         $ref: '../primitive.yaml#/Uint64'
   LightClientFinalityUpdate:
     type: object
+    required: [attested_header, finalized_header, finality_branch, sync_aggregate, signature_slot]
     properties:
       attested_header:
         $ref: '#/Altair/LightClientHeader'
@@ -68,6 +72,7 @@ Altair:
         $ref: '../primitive.yaml#/Uint64'
   LightClientOptimisticUpdate:
     type: object
+    required: [attested_header, sync_aggregate, signature_slot]
     properties:
       attested_header:
         $ref: '#/Altair/LightClientHeader'

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -2,6 +2,7 @@ Altair:
   BeaconState:
     type: object
     description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#beaconstate) object from the CL Altair spec."
+    required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee]
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/altair/sync_aggregate.yaml
+++ b/types/altair/sync_aggregate.yaml
@@ -2,6 +2,7 @@ Altair:
   SyncAggregate:
     type: object
     description: "The [`SyncAggregate`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#syncaggregate) object from the CL Altair spec."
+    required: [sync_committee_bits, sync_committee_signature]
     properties:
       sync_committee_bits:
         $ref: "../primitive.yaml#/BitList"

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -1,6 +1,7 @@
 Altair:
   SyncCommittee:
     type: object
+    required: [pubkeys, aggregate_pubkey]
     properties:
       pubkeys:
         type: array
@@ -13,6 +14,7 @@ Altair:
         $ref: '../primitive.yaml#/Pubkey'
   SyncCommitteeSignature:
       type: object
+      required: [slot, beacon_block_root, validator_index, signature]
       properties:
         slot:
           $ref: '../primitive.yaml#/Uint64'
@@ -24,6 +26,7 @@ Altair:
           $ref: '../primitive.yaml#/Signature'
   SyncCommitteeSubscription:
     type: object
+    required: [validator_index, sync_committee_indices, until_epoch]
     properties:
       validator_index:
         $ref: '../primitive.yaml#/Uint64'
@@ -39,6 +42,7 @@ Altair:
          
   SignedContributionAndProof:
     type: object
+    required: [message, signature]
     properties:
       message:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Altair.ContributionAndProof'
@@ -47,6 +51,7 @@ Altair:
 
   ContributionAndProof:
     type: object
+    required: [aggregator_index, selection_proof, contribution]
     properties:
       aggregator_index:
         allOf:
@@ -59,6 +64,7 @@ Altair:
 
   SyncCommitteeContribution:
     type: object
+    required: [slot, beacon_block_root, subcommittee_index, aggregation_bits, signature]
     properties:
       slot:
         allOf:
@@ -88,6 +94,7 @@ Altair:
         - $ref: '../primitive.yaml#/Uint64'
   SyncCommitteeByValidatorIndices:
     type: object
+    required: [validators, validator_aggregates]
     properties:
       validators:
         allOf:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -2,6 +2,7 @@
 
 DepositSnapshotResponse:
   type: object
+  required: [finalized, deposit_root, deposit_count, execution_block_hash, execution_block_height]
   properties:
     finalized:
       type: array
@@ -21,6 +22,7 @@ DepositSnapshotResponse:
 
 ValidatorResponse:
   type: object
+  required: [index, balance, status, validator]
   properties:
     index:
       allOf:
@@ -37,6 +39,7 @@ ValidatorResponse:
 
 ValidatorBalanceResponse:
   type: object
+  required: [index, balance]
   properties:
     index:
       allOf:
@@ -68,6 +71,7 @@ ValidatorStatus:
 Committee:
   description: Group of validators assigned to attest at specific slot and that have the same committee index (shard in phase 1)
   type: object
+  required: [index, slot, validators]
   properties:
     index:
       allOf:

--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -18,6 +18,7 @@ IndexedAttestation:
 Attestation:
   type: object
   description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attestation) object from the CL spec."
+  required: [aggregation_bits, signature, data]
   properties:
     aggregation_bits:
       $ref: "./primitive.yaml#/BitList"
@@ -32,6 +33,7 @@ Attestation:
 PendingAttestation:
   type: object
   description: "The [`PendingAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#pendingattestation) object from the CL spec."
+  required: [aggregation_bits, data, inclusion_delay, proposer_index]
   properties:
     aggregation_bits:
       $ref: "./primitive.yaml#/BitList"
@@ -46,6 +48,7 @@ PendingAttestation:
 AttestationData:
   type: object
   description: "The [`AttestationData`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attestationdata) object from the CL spec."
+  required: [slot, index, beacon_block_root, source, target]
   properties:
     slot:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/attester_slashing.yaml
+++ b/types/attester_slashing.yaml
@@ -1,6 +1,7 @@
 AttesterSlashing:
   type: object
   description: "The [`AttesterSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attesterslashing) object from the CL spec."
+  required: [attestation_1, attestation_2]
   properties:
     attestation_1:
       $ref: './attestation.yaml#/IndexedAttestation'

--- a/types/bellatrix/block.yaml
+++ b/types/bellatrix/block.yaml
@@ -3,6 +3,7 @@ Bellatrix:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
     description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#beaconblockbody) object from the CL Bellatrix spec."
+    required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate]
     properties:
       randao_reveal:
         allOf:
@@ -39,6 +40,7 @@ Bellatrix:
     allOf:
       - $ref: '#/Bellatrix/BeaconBlockBodyCommon'
       - type: object
+        required: [execution_payload]
         properties:
           execution_payload:
             $ref: './execution_payload.yaml#/Bellatrix/ExecutionPayload'
@@ -48,6 +50,7 @@ Bellatrix:
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Bellatrix/BeaconBlockBody'
@@ -55,6 +58,7 @@ Bellatrix:
   SignedBeaconBlock:
     type: object
     description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Bellatrix/BeaconBlock"
@@ -66,6 +70,7 @@ Bellatrix:
     allOf:
       - $ref: '#/Bellatrix/BeaconBlockBodyCommon'
       - type: object
+        required: [execution_payload_header]
         properties:
           execution_payload_header:
             $ref: './execution_payload.yaml#/Bellatrix/ExecutionPayloadHeader'
@@ -75,6 +80,7 @@ Bellatrix:
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Bellatrix/BlindedBeaconBlockBody'
@@ -82,6 +88,7 @@ Bellatrix:
   SignedBlindedBeaconBlock:
     type: object
     description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Bellatrix spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Bellatrix/BlindedBeaconBlock"

--- a/types/bellatrix/execution_payload.yaml
+++ b/types/bellatrix/execution_payload.yaml
@@ -3,6 +3,7 @@ Bellatrix:
     # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
     type: object
     description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#executionpayload) object from the CL Bellatrix spec."
+    required: [parent_hash, fee_recipient, state_root, receipts_root, logs_bloom, prev_randao, block_number, gas_limit, gas_used, timestamp, extra_data, base_fee_per_gas, block_hash]
     properties:
       parent_hash:
         $ref: '../primitive.yaml#/Root'
@@ -36,6 +37,7 @@ Bellatrix:
     allOf:
       - $ref: '#/Bellatrix/ExecutionPayloadCommon'
       - type: object
+        required: [transactions]
         properties:
           transactions:
             $ref: './transactions.yaml#/Bellatrix/Transactions'
@@ -46,6 +48,7 @@ Bellatrix:
       - $ref: '#/Bellatrix/ExecutionPayloadCommon'
       - type: object
         additionalProperties: false
+        required: [transactions_root]
         properties:
           transactions_root:
             $ref: '../primitive.yaml#/Root'

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -2,6 +2,7 @@ Bellatrix:
   BeaconState:
     type: object
     description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#beaconstate) object from the Eth2.0 Bellatrix spec."
+    required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee, latest_execution_payload_header]
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -1,6 +1,7 @@
 BeaconBlockCommon:
   # An abstract object to collect the common fields between the BeaconBlockHeader and the BeaconBlock objects
   type: object
+  required: [slot, proposer_index, parent_root, state_root]
   properties:
     slot:
       allOf:
@@ -22,6 +23,7 @@ BeaconBlockCommon:
 BeaconBlockBody:
   type: object
   description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblockbody) object from the CL spec."
+  required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits]
   properties:
     randao_reveal:
       allOf:
@@ -58,6 +60,7 @@ BeaconBlock:
   allOf:
     - $ref: '#/BeaconBlockCommon'
     - type: object
+      required: [body]
       properties:
         body:
           $ref: '#/BeaconBlockBody'
@@ -65,6 +68,7 @@ BeaconBlock:
 SignedBeaconBlock:
   type: object
   description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL spec."
+  required: [message, signature]
   properties:
     message:
       $ref: "#/BeaconBlock"
@@ -76,6 +80,7 @@ BeaconBlockHeader:
   allOf:
     - $ref: './block.yaml#/BeaconBlockCommon'
     - type: object
+      required: [body_root]
       properties:
         body_root:
           allOf:
@@ -85,6 +90,7 @@ BeaconBlockHeader:
 SignedBeaconBlockHeader:
   type: object
   description: "The [`SignedBeaconBlockHeader`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblockheader) object envelope from the CL spec."
+  required: [message, signature]
   properties:
     message:
       $ref: "./block.yaml#/BeaconBlockHeader"

--- a/types/bls_to_execution_change.yaml
+++ b/types/bls_to_execution_change.yaml
@@ -1,6 +1,7 @@
 BLSToExecutionChange:
   type: object
   description: "The [`BLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#blstoexecutionchange) object from the CL spec."
+  required: [validator_index, from_bls_pubkey, to_execution_address]
   properties:
     validator_index:
       $ref: "./primitive.yaml#/Uint64"
@@ -15,6 +16,7 @@ BLSToExecutionChange:
 SignedBLSToExecutionChange:
   type: object
   description: "The [`SignedBLSToExecutionChange`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#signedblstoexecutionchange) object from the CL spec."
+  required: [message, signature]
   properties:
     message:
       $ref: "#/BLSToExecutionChange"

--- a/types/capella/block.yaml
+++ b/types/capella/block.yaml
@@ -3,6 +3,7 @@ Capella:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
     description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#beaconblockbody) object from the CL Capella spec."
+    required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate, bls_to_execution_changes]
     properties:
       randao_reveal:
         allOf:
@@ -43,6 +44,7 @@ Capella:
     allOf:
       - $ref: '#/Capella/BeaconBlockBodyCommon'
       - type: object
+        required: [execution_payload]
         properties:
           execution_payload:
             $ref: './execution_payload.yaml#/Capella/ExecutionPayload'
@@ -52,6 +54,7 @@ Capella:
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Capella/BeaconBlockBody'
@@ -59,6 +62,7 @@ Capella:
   SignedBeaconBlock:
     type: object
     description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Capella/BeaconBlock"
@@ -70,6 +74,7 @@ Capella:
     allOf:
       - $ref: '#/Capella/BeaconBlockBodyCommon'
       - type: object
+        required: [execution_payload_header]
         properties:
           execution_payload_header:
             $ref: './execution_payload.yaml#/Capella/ExecutionPayloadHeader'
@@ -79,6 +84,7 @@ Capella:
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Capella/BlindedBeaconBlockBody'
@@ -86,6 +92,7 @@ Capella:
   SignedBlindedBeaconBlock:
     type: object
     description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Capella spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Capella/BlindedBeaconBlock"

--- a/types/capella/execution_payload.yaml
+++ b/types/capella/execution_payload.yaml
@@ -3,6 +3,7 @@ Capella:
     # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
     type: object
     description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#executionpayload) object from the CL Capella spec."
+    required: [parent_hash, fee_recipient, state_root, receipts_root, logs_bloom, prev_randao, block_number, gas_limit, gas_used, timestamp, extra_data, base_fee_per_gas, block_hash]
     properties:
       parent_hash:
         $ref: '../primitive.yaml#/Root'
@@ -36,6 +37,7 @@ Capella:
     allOf:
       - $ref: '#/Capella/ExecutionPayloadCommon'
       - type: object
+        required: [transactions, withdrawals]
         properties:
           transactions:
             $ref: '../bellatrix/transactions.yaml#/Bellatrix/Transactions'
@@ -48,6 +50,7 @@ Capella:
       - $ref: '#/Capella/ExecutionPayloadCommon'
       - type: object
         additionalProperties: false
+        required: [transactions_root, withdrawals_root]
         properties:
           transactions_root:
             $ref: '../primitive.yaml#/Root'

--- a/types/capella/historical_summary.yaml
+++ b/types/capella/historical_summary.yaml
@@ -2,6 +2,7 @@ Capella:
   HistoricalSummary:
     type: object
     description:  "The [`HistoricalSummary`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#historicalsummary) object from the CL Capella spec."
+    required: [block_summary_root, state_summary_root]
     properties:
       block_summary_root:
         $ref: '../primitive.yaml#/Root'

--- a/types/capella/light_client.yaml
+++ b/types/capella/light_client.yaml
@@ -9,6 +9,7 @@ Capella:
 
   LightClientHeader:
     type: object
+    required: [beacon, execution, execution_branch]
     properties:
       beacon:
         $ref: '../block.yaml#/BeaconBlockHeader'
@@ -19,6 +20,7 @@ Capella:
 
   LightClientBootstrap:
     type: object
+    required: [header, current_sync_committee, current_sync_committee_branch]
     properties:
       header:
         $ref: '#/Capella/LightClientHeader'
@@ -28,6 +30,7 @@ Capella:
         $ref: '../altair/light_client.yaml#/Altair/CurrentSyncCommitteeBranch'
   LightClientUpdate:
     type: object
+    required: [attested_header, next_sync_committee, next_sync_committee_branch, finalized_header, finality_branch, sync_aggregate, signature_slot]
     properties:
       attested_header:
         $ref: '#/Capella/LightClientHeader'
@@ -45,6 +48,7 @@ Capella:
         $ref: '../primitive.yaml#/Uint64'
   LightClientFinalityUpdate:
     type: object
+    required: [attested_header, finalized_header, finality_branch, sync_aggregate, signature_slot]
     properties:
       attested_header:
         $ref: '#/Capella/LightClientHeader'
@@ -58,6 +62,7 @@ Capella:
         $ref: '../primitive.yaml#/Uint64'
   LightClientOptimisticUpdate:
     type: object
+    required: [attested_header, sync_aggregate, signature_slot]
     properties:
       attested_header:
         $ref: '#/Capella/LightClientHeader'

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -2,6 +2,7 @@ Capella:
   BeaconState:
     type: object
     description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#beaconstate) object from the Eth2.0 Capella spec."
+    required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee, latest_execution_payload_header, next_withdrawal_index, next_withdrawal_validator_index, historical_summaries]
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/deneb/blob_sidecar.yaml
+++ b/types/deneb/blob_sidecar.yaml
@@ -16,6 +16,7 @@ Deneb:
   BlobSidecar:
     type: object
     description: "A blob sidecar as defined in the Deneb consensus spec."
+    required: [index, blob, kzg_commitment, kzg_proof, signed_block_header, kzg_commitment_inclusion_proof]
     properties:
       index:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/deneb/block.yaml
+++ b/types/deneb/block.yaml
@@ -3,6 +3,7 @@ Deneb:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
     description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#beaconblockbody) object from the CL Deneb spec."
+    required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate, bls_to_execution_changes, blob_kzg_commitments]
     properties:
       randao_reveal:
         allOf:
@@ -47,6 +48,7 @@ Deneb:
     allOf:
       - $ref: '#/Deneb/BeaconBlockBodyCommon'
       - type: object
+        required: [execution_payload]
         properties:
           execution_payload:
             $ref: './execution_payload.yaml#/Deneb/ExecutionPayload'
@@ -56,6 +58,7 @@ Deneb:
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Deneb/BeaconBlockBody'
@@ -63,6 +66,7 @@ Deneb:
   SignedBeaconBlock:
     type: object
     description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#signedbeaconblock) object envelope from the CL Deneb spec."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Deneb/BeaconBlock"
@@ -74,6 +78,7 @@ Deneb:
     allOf:
       - $ref: '#/Deneb/BeaconBlockBodyCommon'
       - type: object
+        required: [execution_payload_header]
         properties:
           execution_payload_header:
             $ref: './execution_payload.yaml#/Deneb/ExecutionPayloadHeader'
@@ -83,6 +88,7 @@ Deneb:
     allOf:
       - $ref: '../altair/block.yaml#/Altair/BeaconBlockCommon'
       - type: object
+        required: [body]
         properties:
           body:
             $ref: '#/Deneb/BlindedBeaconBlockBody'
@@ -90,6 +96,7 @@ Deneb:
   SignedBlindedBeaconBlock:
     type: object
     description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#signedbeaconblock) object envelope from the CL Deneb spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    required: [message, signature]
     properties:
       message:
         $ref: "#/Deneb/BlindedBeaconBlock"

--- a/types/deneb/block_contents.yaml
+++ b/types/deneb/block_contents.yaml
@@ -16,6 +16,7 @@ Deneb:
   BlockContents:
     type: object
     description: "The required object for block production according to the Deneb CL spec."
+    required: [block, kzg_proofs, blobs]
     properties:
       block:
         $ref: "./block.yaml#/Deneb/BeaconBlock"
@@ -27,6 +28,7 @@ Deneb:
   SignedBlockContents:
     type: object
     description: "The required signed components of block production according to the Deneb CL spec."
+    required: [signed_block, kzg_proofs, blobs]
     properties:
       signed_block:
         $ref: "./block.yaml#/Deneb/SignedBeaconBlock"

--- a/types/deneb/execution_payload.yaml
+++ b/types/deneb/execution_payload.yaml
@@ -3,6 +3,7 @@ Deneb:
     # An abstract object to collect the common fields between the ExecutionPayload and the ExecutionPayloadHeader objects.
     type: object
     description: "The [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#executionpayload) object from the CL Deneb spec."
+    required: [parent_hash, fee_recipient, state_root, receipts_root, logs_bloom, prev_randao, block_number, gas_limit, gas_used, timestamp, extra_data, base_fee_per_gas, excess_data_gas, block_hash]
     properties:
       parent_hash:
         $ref: '../primitive.yaml#/Root'
@@ -38,6 +39,7 @@ Deneb:
     allOf:
       - $ref: '#/Deneb/ExecutionPayloadCommon'
       - type: object
+        required: [transactions, withdrawals]
         properties:
           transactions:
             $ref: '../bellatrix/transactions.yaml#/Bellatrix/Transactions'
@@ -49,6 +51,7 @@ Deneb:
     allOf:
       - $ref: '#/Deneb/ExecutionPayloadCommon'
       - type: object
+        required: [transactions_root, withdrawals_root]
         properties:
           transactions_root:
             $ref: '../primitive.yaml#/Root'

--- a/types/deneb/state.yaml
+++ b/types/deneb/state.yaml
@@ -2,6 +2,7 @@ Deneb:
   BeaconState:
     type: object
     description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#beaconstate) object from the Eth2.0 Deneb spec."
+    required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee, latest_execution_payload_header, next_withdrawal_index, next_withdrawal_validator_index, historical_summaries]
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"

--- a/types/deposit.yaml
+++ b/types/deposit.yaml
@@ -1,6 +1,7 @@
 Deposit:
   type: object
   description: "The [`Deposit`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#deposit) object from the CL spec."
+  required: [proof, data]
   properties:
     proof:
       type: array
@@ -15,6 +16,7 @@ Deposit:
 DepositData:
   type: object
   description: "The [`DepositData`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#depositdata) object from the CL spec."
+  required: [pubkey, withdrawal_credentials, amount, signature]
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'

--- a/types/eth1.yaml
+++ b/types/eth1.yaml
@@ -1,6 +1,7 @@
 Eth1Data:
   type: object
   description: "The [`Eth1Data`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#eth1data) object from the CL spec."
+  required: [deposit_root, deposit_count, block_hash]
   properties:
     deposit_root:
       allOf:

--- a/types/fork_choice.yaml
+++ b/types/fork_choice.yaml
@@ -1,6 +1,7 @@
 Node:
   type: object
   description: "fork choice node attributes"
+  required: [slot, block_root, parent_root, justified_epoch, finalized_epoch, weight, validity, execution_block_hash]
   properties:
     slot:
       allOf:

--- a/types/http.yaml
+++ b/types/http.yaml
@@ -4,6 +4,7 @@ InvalidRequest:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "Either specific error code in case of invalid request or http status code"
@@ -23,6 +24,7 @@ InternalError:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "Either specific error code in case of invalid request or http status code"
@@ -45,6 +47,7 @@ NotImplementedError:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "Either specific error code in case of invalid request or http status code"
@@ -67,6 +70,7 @@ CurrentlySyncing:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "Either specific error code in case of invalid request or http status code"
@@ -89,6 +93,7 @@ NotFound:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "Either specific error code in case of invalid request or http status code"
@@ -111,6 +116,7 @@ UnsupportedMediaType:
     application/json:
       schema:
         type: object
+        required: [code, message]
         properties:
           code:
             description: "The media type supplied is unsupported, and the request has been rejected. This occurs when a HTTP request supplies a payload in a content-type that the service is not able to accept."
@@ -129,6 +135,7 @@ UnsupportedMediaType:
         message: "Cannot read the supplied content type."
 ErrorMessage:
   type: object
+  required: [code, message]
   properties:
     code:
       description: "Either specific error code in case of invalid request or http status code"
@@ -144,6 +151,7 @@ ErrorMessage:
         type: string
 IndexedErrorMessage:
   type: object
+  required: [code, message, failures]
   properties:
     code:
       description: "Either specific error code in case of invalid request or http status code"
@@ -158,6 +166,7 @@ IndexedErrorMessage:
       type: array
       items:
         type: object
+        required: [index, message]
         properties:
           index:
             description: "Index of item in the request list that caused the error"

--- a/types/misc.yaml
+++ b/types/misc.yaml
@@ -1,6 +1,7 @@
 Fork:
   type: object
   description: "The [`Fork`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#fork) object from the CL spec."
+  required: [previous_version, current_version, epoch]
   properties:
     previous_version:
       $ref: "./primitive.yaml#/ForkVersion"
@@ -12,6 +13,7 @@ Fork:
 Checkpoint:
   type: object
   description: "The [`Checkpoint`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#checkpoint"
+  required: [epoch, root]
   properties:
     epoch:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -1,5 +1,6 @@
 NetworkIdentity:
   type: object
+  required: [peer_id, enr, p2p_addresses, discovery_addresses, metadata]
   properties:
     peer_id:
       $ref: "./p2p.yaml#/PeerId"
@@ -24,7 +25,7 @@ NetworkIdentity:
 MetaData:
   type: object
   description: "Based on eth2 [Metadata object](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#metadata)"
-  required: ["seq_number", "attnets"]
+  required: [seq_number, attnets]
   properties:
     seq_number:
       allOf:
@@ -43,6 +44,7 @@ MetaData:
 
 Peer:
   type: object
+  required: [peer_id, enr, last_seen_p2p_address, state, direction]
   properties:
     peer_id:
       $ref: "./p2p.yaml#/PeerId"

--- a/types/proposer_slashing.yaml
+++ b/types/proposer_slashing.yaml
@@ -1,6 +1,7 @@
 ProposerSlashing:
   type: object
   description: "The [`ProposerSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#proposerslashing) object from the CL spec."
+  required: [signed_header_1, signed_header_2]
   properties:
     signed_header_1:
       $ref: './block.yaml#/SignedBeaconBlockHeader'

--- a/types/registration.yaml
+++ b/types/registration.yaml
@@ -1,6 +1,7 @@
 ValidatorRegistration:
   type: object
   description: "The `ValidatorRegistration` object from the Builder API specification."
+  required: [fee_recipient, gas_limit, timestamp, pubkey]
   properties:
     fee_recipient:
       $ref: 'primitive.yaml#/ExecutionAddress'
@@ -18,6 +19,7 @@ ValidatorRegistration:
 SignedValidatorRegistration:
   type: object
   description: "The `SignedValidatorRegistration` object from the Builder API specification."
+  required: [message, signature]
   properties:
     message:
       $ref: "#/ValidatorRegistration"

--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -4,7 +4,7 @@ SyncCommitteeRewards:
   items:
     type: object
     description: "Rewards info for a single sync committee member"
-    required: ["validator_index", "reward"]
+    required: [validator_index, reward]
     properties:
       validator_index:
         allOf:
@@ -20,7 +20,7 @@ SyncCommitteeRewards:
 AttestationsRewards:
   type: object
   description: "Rewards info for attestations"
-  required: ["ideal_rewards", "total_rewards"]
+  required: [ideal_rewards, total_rewards]
   properties:
     ideal_rewards:
       type: array
@@ -34,7 +34,7 @@ AttestationsRewards:
 AttestationRewards:
   type: object
   description: "Rewards info for a single attestation"
-  required: ["validator_index", "head", "target", "source", "inactivity"]
+  required: [validator_index, head, target, source, inactivity]
   properties:
       validator_index:
         allOf:
@@ -70,7 +70,7 @@ AttestationRewards:
 IdealAttestationRewards:
   type: object
   description: "Ideal rewards info for a single attestation"
-  required: ["effective_balance", "head", "target", "source", "inactivity"]
+  required: [effective_balance, head, target, source, inactivity]
   properties:
     effective_balance:
       allOf:
@@ -106,6 +106,7 @@ IdealAttestationRewards:
 BlockRewards:
   type: object
   description: "Rewards info for a single block"
+  required: [proposer_index, total, attestations, sync_aggregate, proposer_slashings, attester_slashings]
   properties:
     proposer_index:
       allOf:

--- a/types/selection.yaml
+++ b/types/selection.yaml
@@ -1,5 +1,6 @@
 BeaconCommitteeSelection:
   type: object
+  required: [validator_index, slot, selection_proof]
   properties:
     validator_index:
       allOf:
@@ -16,6 +17,7 @@ BeaconCommitteeSelection:
 
 SyncCommitteeSelection:
   type: object
+  required: [validator_index, slot, subcommittee_index, selection_proof]
   properties:
     validator_index:
       allOf:

--- a/types/state.yaml
+++ b/types/state.yaml
@@ -1,6 +1,7 @@
 BeaconState:
   type: object
   description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock) object from the CL spec."
+  required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_attestations, current_epoch_attestations, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint]
   properties:
     genesis_time:
       $ref: "./primitive.yaml#/Uint64"

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -1,5 +1,6 @@
 Validator:
   type: object
+  required: [pubkey, withdrawal_credentials, effective_balance, slashed, activation_eligibility_epoch, activation_epoch, exit_epoch, withdrawable_epoch]
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
@@ -34,6 +35,7 @@ Validator:
 
 AttesterDuty:
   type: object
+  required: [pubkey, validator_index, committee_index, committee_length, committees_at_slot, validator_committee_index, slot]
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
@@ -64,6 +66,7 @@ AttesterDuty:
 
 ProposerDuty:
   type: object
+  required: [pubkey, validator_index, slot]
   properties:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
@@ -79,6 +82,7 @@ ProposerDuty:
 Altair:
   SyncDuty:
     type: object
+    required: [pubkey, validator_index, validator_sync_committee_indices]
     properties:
       pubkey:
         $ref: './primitive.yaml#/Pubkey'
@@ -97,6 +101,7 @@ AggregateAndProof:
   allOf:
     - $ref: '#/Aggregate'
     - type: object
+      required: [selection_proof]
       properties:
         selection_proof:
           $ref: './primitive.yaml#/Signature'
@@ -104,6 +109,7 @@ AggregateAndProof:
 Aggregate:
   type: object
   description: "The [`AggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#aggregateandproof) without selection_proof"
+  required: [aggregator_index, aggregate]
   properties:
     aggregator_index:
       $ref: './primitive.yaml#/Uint64'
@@ -114,6 +120,7 @@ Aggregate:
 SignedAggregateAndProof:
   type: object
   description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#signedaggregateandproof) object"
+  required: [message, signature]
   properties:
     message:
       $ref: "#/AggregateAndProof"

--- a/types/voluntary_exit.yaml
+++ b/types/voluntary_exit.yaml
@@ -1,6 +1,7 @@
 VoluntaryExit:
   type: object
   description: "The [`VoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#voluntaryexit) object from the CL spec."
+  required: [epoch, validator_index]
   properties:
     epoch:
       allOf:
@@ -14,6 +15,7 @@ VoluntaryExit:
 SignedVoluntaryExit:
   type: object
   description: "The [`SignedVoluntaryExit`](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedvoluntaryexit) object from the CL spec."
+  required: [message, signature]
   properties:
     message:
       $ref: "#/VoluntaryExit"

--- a/types/withdrawal.yaml
+++ b/types/withdrawal.yaml
@@ -1,5 +1,6 @@
 Withdrawal:
   type: object
+  required: [index, validator_index, address, amount]
   properties:
     index:
       $ref: './primitive.yaml#/Uint64'


### PR DESCRIPTION
**Motivation**

As mentioned in https://github.com/ethereum/beacon-APIs/pull/388#issuecomment-1864843080 I think it would be good practice to add the `required` field to object and request body definitions.

This main reasons for this are
- openapi spec compliance / technical correctness
- detect missing properties during schema validation by using [ajv](https://github.com/ajv-validator/ajv) or similar tooling
- allows to generate correct types via [openapi-generator](https://github.com/OpenAPITools/openapi-generator), properties are no longer optional (type safety)
- clarity on how to make properties optional (https://github.com/ethereum/beacon-APIs/pull/388)

**Description**
- Add required properties to object types
- Add required field to request bodies