### PR TITLE
Clarify that payload & block values are in Wei

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -420,12 +420,16 @@ components:
       schema:
         type: boolean
     Eth-Execution-Payload-Value:
-      description: Required in response so client can determine relative value of execution payloads.
+      description: |
+        Execution payload value in Wei. Required in response so client can determine relative value
+        of execution payloads.
       required: true
       schema:
         $ref: './types/primitive.yaml#/Wei'
     Eth-Consensus-Block-Value:
-      description: Required in response so client can determine relative value of consensus blocks.
+      description: |
+        Consensus rewards paid to the proposer for this block, in Wei. Required in response so
+        client can determine relative value of consensus blocks.
       required: true
       schema:
         $ref: './types/primitive.yaml#/Wei'


### PR DESCRIPTION
Require both execution payload value and consensus block value to be denominated in _wei_.

There are advantages to wei+gwei or wei+wei, and we just need to choose one. I've chosen to use the wei+wei option, because the consistency makes the API less confusing, and I think this trumps concerns about performance or unnecessary zero padding.

Closes #397