### PR TITLE
Quote uint64 and int64 examples

### DIFF
--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -9,12 +9,12 @@ SyncCommitteeRewards:
       validator_index:
         allOf:
           - $ref: "./primitive.yaml#/Uint64"
-          - example: 0
+          - example: "0"
           - description: "one entry for every validator participating in the sync committee"
       reward:
         allOf:
           - $ref: "./primitive.yaml#/Int64"
-          - example: 2000
+          - example: "2000"
           - description: "sync committee reward in gwei for the validator"
 
 AttestationsRewards:
@@ -39,32 +39,32 @@ AttestationRewards:
       validator_index:
         allOf:
           - $ref: "./primitive.yaml#/Uint64"
-          - example: 0
+          - example: "0"
           - description: "one entry for every validator based on their attestations in the epoch"
       head:
         allOf:
           - $ref: "./primitive.yaml#/Int64"
-          - example: 2000
+          - example: "2000"
           - description: "attester's reward for head vote in gwei"
       target:
         allOf:
           - $ref: "./primitive.yaml#/Int64"
-          - example: 2000
+          - example: "2000"
           - description: "attester's reward for target vote in gwei"
       source:
         allOf:
           - $ref: "./primitive.yaml#/Int64"
-          - example: 4000
+          - example: "4000"
           - description: "attester's reward for source vote in gwei"
       inclusion_delay:
         allOf:
           - $ref: "./primitive.yaml#/Uint64"
-          - example: 2000
+          - example: "2000"
           - description: "attester's inclusion_delay reward in gwei (phase0 only)"
       inactivity:
         allOf:
           - $ref: "./primitive.yaml#/Int64"
-          - example: 2000
+          - example: "2000"
           - description: "attester's inactivity penalty in gwei"
 
 IdealAttestationRewards:
@@ -75,32 +75,32 @@ IdealAttestationRewards:
     effective_balance:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 1000000000
+        - example: "1000000000"
         - description: "validator's effective balance in gwei"
     head:
       allOf:
         - $ref: "./primitive.yaml#/Int64"
-        - example: 2500
+        - example: "2500"
         - description: "Ideal attester's reward for head vote in gwei"
     target:
       allOf:
         - $ref: "./primitive.yaml#/Int64"
-        - example: 5000
+        - example: "5000"
         - description: "Ideal attester's reward for target vote in gwei"
     source:
       allOf:
         - $ref: "./primitive.yaml#/Int64"
-        - example: 5000
+        - example: "5000"
         - description: "Ideal attester's reward for source vote in gwei"
     inclusion_delay:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 5000
+        - example: "5000"
         - description: "Ideal attester's inclusion_delay reward in gwei (phase0 only)"
     inactivity:
       allOf:
         - $ref: "./primitive.yaml#/Int64"
-        - example: 5000
+        - example: "5000"
         - description: "Ideal attester's inactivity penalty in gwei"
 
 BlockRewards:
@@ -110,30 +110,30 @@ BlockRewards:
     proposer_index:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 123
+        - example: "123"
         - description: "proposer of the block, the proposer index who receives these rewards"
     total:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 123
+        - example: "123"
         - description: "total block reward in gwei, equal to attestations + sync_aggregate + proposer_slashings + attester_slashings"
     attestations:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 123
+        - example: "123"
         - description: "block reward component due to included attestations in gwei"
     sync_aggregate:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 123
+        - example: "123"
         - description: "block reward component due to included sync_aggregate in gwei"
     proposer_slashings:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 123
+        - example: "123"
         - description: "block reward component due to included proposer_slashings in gwei"
     attester_slashings:
       allOf:
         - $ref: "./primitive.yaml#/Uint64"
-        - example: 123
+        - example: "123"
         - description: "block reward component due to included attester_slashings in gwei"


### PR DESCRIPTION
Both uint64 and int64 are defined are quoted numbers, fix examples to align with their type.

https://github.com/ethereum/beacon-APIs/blob/4882aa0803b622b75bab286b285599d70b7a2429/types/primitive.yaml#L32-L34

https://github.com/ethereum/beacon-APIs/blob/4882aa0803b622b75bab286b285599d70b7a2429/types/primitive.yaml#L40-L42

For reference Lighthouse stable quotes all integers in the rewards API

https://github.com/sigp/lighthouse/blob/441fc1691b69f9edc4bbdc6665f3efab16265c9b/common/eth2/src/lighthouse/attestation_rewards.rs#L8-L27