### PR TITLE
fix: remove unneeded allOf usages

### DIFF
--- a/apis/beacon/blob_sidecars/blob_sidecars.yaml
+++ b/apis/beacon/blob_sidecars/blob_sidecars.yaml
@@ -44,17 +44,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/attestations.yaml
+++ b/apis/beacon/blocks/attestations.yaml
@@ -34,17 +34,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/blinded_block.yaml
+++ b/apis/beacon/blocks/blinded_block.yaml
@@ -47,20 +47,18 @@ get:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Invalid block ID: current"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 404
-                  message: "Block not found"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -69,9 +69,9 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block: missing signature"
+          example:
+            code: 400
+            message: "Invalid block: missing signature"
     "415":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -47,9 +47,9 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block: missing signature"
+          example:
+            code: 400
+            message: "Invalid block: missing signature"
     "415":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":

--- a/apis/beacon/blocks/block.v2.yaml
+++ b/apis/beacon/blocks/block.v2.yaml
@@ -49,17 +49,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/block.yaml
+++ b/apis/beacon/blocks/block.yaml
@@ -39,18 +39,18 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"
 

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -67,11 +67,10 @@ post:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Invalid block: missing signature"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid block: missing signature"
     "415":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -45,11 +45,10 @@ post:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Invalid block: missing signature"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid block: missing signature"
     "415":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":

--- a/apis/beacon/blocks/header.yaml
+++ b/apis/beacon/blocks/header.yaml
@@ -39,17 +39,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/headers.yaml
+++ b/apis/beacon/blocks/headers.yaml
@@ -9,16 +9,12 @@ get:
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
     - name: parent_root
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"
-          - example: ""
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Root"
 
   responses:
     "200":
@@ -52,8 +48,8 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/blocks/root.yaml
+++ b/apis/beacon/blocks/root.yaml
@@ -34,26 +34,25 @@ get:
                 required: [root]
                 properties:
                   root:
-                    allOf:
-                      - description: HashTreeRoot of BeaconBlock/BeaconBlockHeader object
-                      - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                    description: HashTreeRoot of BeaconBlock/BeaconBlockHeader object
+                    $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
     "400":
       description: "The block ID supplied could not be parsed"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block ID: current"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
     "404":
       description: "Block not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/deposit_snapshot.yaml
+++ b/apis/beacon/deposit_snapshot.yaml
@@ -26,10 +26,9 @@
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-                - example:
-                    code: 404
-                    message: "No Finalized Snapshot Available"
+              $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            example:
+              code: 404
+              message: "No Finalized Snapshot Available"
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/genesis.yaml
+++ b/apis/beacon/genesis.yaml
@@ -31,8 +31,8 @@
           application/json:
             schema:
               $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              example:
-                code: 404
-                message: "Chain genesis info is not yet known"
+            example:
+              code: 404
+              message: "Chain genesis info is not yet known"
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/light_client/bootstrap.yaml
+++ b/apis/beacon/light_client/bootstrap.yaml
@@ -41,26 +41,26 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid block root value"
+          example:
+            code: 400
+            message: "Invalid block root value"
     "404":
       description: "`LightClientBootstrap` instance cannot be produced for the given block root"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "LC bootstrap unavailable"
+          example:
+            code: 404
+            message: "LC bootstrap unavailable"
     "406":
       description: Unacceptable media type
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 406
-              message: "Accepted media type not supported"
+          example:
+            code: 406
+            message: "Accepted media type not supported"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/light_client/finality_update.yaml
+++ b/apis/beacon/light_client/finality_update.yaml
@@ -36,17 +36,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "LC finality update unavailable"
+          example:
+            code: 404
+            message: "LC finality update unavailable"
     "406":
       description: Unacceptable media type
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 406
-              message: "Accepted media type not supported"
+          example:
+            code: 406
+            message: "Accepted media type not supported"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/light_client/optimistic_update.yaml
+++ b/apis/beacon/light_client/optimistic_update.yaml
@@ -36,17 +36,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "LC optimistic update unavailable"
+          example:
+            code: 404
+            message: "LC optimistic update unavailable"
     "406":
       description: Unacceptable media type
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 406
-              message: "Accepted media type not supported"
+          example:
+            code: 406
+            message: "Accepted media type not supported"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/light_client/updates.yaml
+++ b/apis/beacon/light_client/updates.yaml
@@ -90,8 +90,8 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 406
-              message: "Accepted media type not supported"
+          example:
+            code: 406
+            message: "Accepted media type not supported"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/pool/attestations.yaml
+++ b/apis/beacon/pool/attestations.yaml
@@ -35,9 +35,9 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid slot: current"
+          example:
+            code: 400
+            message: "Invalid slot: current"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/pool/attester_slashings.yaml
+++ b/apis/beacon/pool/attester_slashings.yaml
@@ -42,8 +42,8 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid attester slashing, it will never pass validation so it's rejected"
+          example:
+            code: 400
+            message: "Invalid attester slashing, it will never pass validation so it's rejected"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/pool/proposer_slashings.yaml
+++ b/apis/beacon/pool/proposer_slashings.yaml
@@ -42,8 +42,8 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid proposer slashing, it will never pass validation so it's rejected"
+          example:
+            code: 400
+            message: "Invalid proposer slashing, it will never pass validation so it's rejected"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/pool/voluntary_exists.yaml
+++ b/apis/beacon/pool/voluntary_exists.yaml
@@ -42,8 +42,8 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid voluntary exit, it will never pass validation so it's rejected"
+          example:
+            code: 400
+            message: "Invalid voluntary exit, it will never pass validation so it's rejected"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/rewards/sync_committee.yaml
+++ b/apis/beacon/rewards/sync_committee.yaml
@@ -56,8 +56,8 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Block not found"
+          example:
+            code: 404
+            message: "Block not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/states/committee.yaml
+++ b/apis/beacon/states/committee.yaml
@@ -14,25 +14,19 @@ get:
       required: false
       allowEmptyValue: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
     - name: index
       description: "Restrict returned values to those matching the supplied committee index."
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
     - name: slot
       description: "Restrict returned values to those matching the supplied slot."
       in: query
       required: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
   responses:
     "200":
       description: Success
@@ -57,9 +51,9 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Slot does not belong in epoch"
+          example:
+            code: 400
+            message: "Slot does not belong in epoch"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/finality_checkpoints.yaml
+++ b/apis/beacon/states/finality_checkpoints.yaml
@@ -40,18 +40,18 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/states/fork.yaml
+++ b/apis/beacon/states/fork.yaml
@@ -32,17 +32,17 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/states/randao.yaml
+++ b/apis/beacon/states/randao.yaml
@@ -21,9 +21,7 @@ get:
       required: false
       allowEmptyValue: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
   responses:
     "200":
       description: Success
@@ -43,26 +41,23 @@ get:
                 required: [randao]
                 properties:
                   randao:
-                    allOf:
-                      - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
-                      - description: RANDAO mix for requested epoch in state.
+                    $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                    description: RANDAO mix for requested epoch in state.
     "400":
       description: "Invalid state ID or epoch"
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Epoch is out of range for the `randao_mixes` of the state"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Epoch is out of range for the `randao_mixes` of the state"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
           example:
             code: 404
             message: "State not found"

--- a/apis/beacon/states/root.yaml
+++ b/apis/beacon/states/root.yaml
@@ -27,18 +27,17 @@ get:
                 required: [root]
                 properties:
                   root:
-                    allOf:
-                      - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
-                      - description: HashTreeRoot of BeaconState object
+                    $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Root'
+                    description: HashTreeRoot of BeaconState object
     "400":
       description: "Invalid state ID"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/sync_committees.yaml
+++ b/apis/beacon/states/sync_committees.yaml
@@ -14,9 +14,7 @@ get:
       required: false
       allowEmptyValue: false
       schema:
-        allOf:
-          - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-          - example: ""
+        $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Uint64'
   responses:
     "200":
       description: Success
@@ -40,9 +38,9 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Epoch is outside the sync committee period of the state"
+          example:
+            code: 400
+            message: "Epoch is outside the sync committee period of the state"
     "404":
       description: "State not found"
       content:

--- a/apis/beacon/states/validator.yaml
+++ b/apis/beacon/states/validator.yaml
@@ -38,9 +38,9 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "Not Found"
       content:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -50,27 +50,27 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "414":
       description: "Too many validator IDs"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 414
-              message: "Too many validator IDs in request"
+          example:
+            code: 414
+            message: "Too many validator IDs in request"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 post:
@@ -124,17 +124,17 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -61,27 +61,27 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "414":
       description: "Too many validator IDs"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 414
-              message: "Too many validator IDs in request"
+          example:
+            code: 414
+            message: "Too many validator IDs in request"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"
 post:
@@ -149,17 +149,17 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "500":
       $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/builder/states/expected_withdrawals.yaml
+++ b/apis/builder/states/expected_withdrawals.yaml
@@ -43,18 +43,16 @@ get:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "The specified state is not a capella state."
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "The specified state is not a capella state."
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
           example:
             code: 404
             message: "State not found"

--- a/apis/config/deposit_contract.yaml
+++ b/apis/config/deposit_contract.yaml
@@ -19,14 +19,12 @@ get:
                 required: [chain_id, address]
                 properties:
                   chain_id:
-                    allOf:
-                      - $ref: ../../beacon-node-oapi.yaml#/components/schemas/Uint64
-                      - description: Id of Eth1 chain on which contract is deployed.
-                      - example: "1"
+                    $ref: ../../beacon-node-oapi.yaml#/components/schemas/Uint64
+                    description: Id of Eth1 chain on which contract is deployed.
+                    example: "1"
                   address:
-                    allOf:
-                      - $ref: ../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress
-                      - description: Hex encoded deposit contract address with 0x prefix
-                      - example: "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+                    $ref: ../../beacon-node-oapi.yaml#/components/schemas/ExecutionAddress
+                    description: Hex encoded deposit contract address with 0x prefix
+                    example: "0x00000000219ab540356cBB839Cbe05303d7705Fa"
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -48,18 +48,18 @@ get:
         application/json:
           schema:
             $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid state ID: current"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
     "404":
       description: "State not found"
       content:
         application/json:
           schema:
             $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "State not found"
+          example:
+            code: 404
+            message: "State not found"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -146,9 +146,9 @@ get:
         application/json:
           schema:
             $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid topic: weather_forecast"
+          example:
+            code: 400
+            message: "Invalid topic: weather_forecast"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
       

--- a/apis/node/peer.yaml
+++ b/apis/node/peer.yaml
@@ -28,17 +28,17 @@ get:
         application/json:
           schema:
             $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid peer ID: localhost"
+          example:
+            code: 400
+            message: "Invalid peer ID: localhost"
     "404":
       description: "Peer not found"
       content:
         application/json:
           schema:
             $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 404
-              message: "Peer not found"
+          example:
+            code: 404
+            message: "Peer not found"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/node/peer_count.yaml
+++ b/apis/node/peer_count.yaml
@@ -19,20 +19,16 @@ get:
                 required: [disconnected, connecting, connected, disconnecting]
                 properties: 
                   disconnected:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "12"
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                    example: "12"
                   connecting:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "34"
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                    example: "34"
                   connected:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "56"
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                    example: "56"
                   disconnecting:
-                    allOf:
-                      - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                      - example: "5"
+                    $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                    example: "5"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/node/syncing.yaml
+++ b/apis/node/syncing.yaml
@@ -20,24 +20,19 @@
                   required: [head_slot, sync_distance, is_syncing, is_optimistic, el_offline]
                   properties:
                     head_slot:
-                      allOf:
-                        - description: "Head slot node is trying to reach"
-                        - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                      description: "Head slot node is trying to reach"
+                      $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     sync_distance:
-                      allOf:
-                        - description: "How many slots node needs to process to reach head. 0 if synced."
-                        - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+                      description: "How many slots node needs to process to reach head. 0 if synced."
+                      $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
                     is_syncing:
-                      allOf:
-                        - type: boolean
-                        - description: "Set to true if the node is syncing, false if the node is synced."
+                      type: boolean
+                      description: "Set to true if the node is syncing, false if the node is synced."
                     is_optimistic:
-                      allOf:
-                        - type: boolean
-                        - description: "Set to true if the node is optimistically tracking head."
+                      type: boolean
+                      description: "Set to true if the node is optimistically tracking head."
                     el_offline:
-                      allOf:
-                        - type: boolean
-                        - description: "Set to true if the execution client is offline."
+                      type: boolean
+                      description: "Set to true if the execution client is offline."
       "500":
         $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/beacon_committee_subscriptions.yaml
+++ b/apis/validator/beacon_committee_subscriptions.yaml
@@ -27,13 +27,11 @@ post:
               committee_index:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
               committees_at_slot:
-                allOf:
-                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                  - description: "Number of committees at the returned slot"
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                description: "Number of committees at the returned slot"
               slot:
-                allOf:
-                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
-                  - description: "Should be slot at which validator is assigned to attest"
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+                description: "Should be slot at which validator is assigned to attest"
               is_aggregator:
                 type: boolean
                 description: "Signals to BN that a validator on the VC has been chosen for aggregator role."

--- a/apis/validator/duties/attester.yaml
+++ b/apis/validator/duties/attester.yaml
@@ -63,9 +63,9 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid epoch: -2"
+          example:
+            code: 400
+            message: "Invalid epoch: -2"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/apis/validator/duties/proposer.yaml
+++ b/apis/validator/duties/proposer.yaml
@@ -47,9 +47,9 @@ get:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-            example:
-              code: 400
-              message: "Invalid epoch: -2"
+          example:
+            code: 400
+            message: "Invalid epoch: -2"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/apis/validator/duties/sync.yaml
+++ b/apis/validator/duties/sync.yaml
@@ -44,10 +44,10 @@ post:
       content:
         application/json:
           schema:
-              $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              example:
-                code: 400
-                message: "Invalid epoch: -2"
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid epoch: -2"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/apis/validator/liveness.yaml
+++ b/apis/validator/liveness.yaml
@@ -55,11 +55,10 @@ post:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
-              - example:
-                  code: 400
-                  message: "Invalid epoch: -2"
+            $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid epoch: -2"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":

--- a/types/altair/block.yaml
+++ b/types/altair/block.yaml
@@ -5,21 +5,17 @@ Altair:
     required: [slot, proposer_index, parent_root, state_root]
     properties:
       slot:
-        allOf:
-          - $ref: "../primitive.yaml#/Uint64"
-          - description: "The slot to which this block corresponds."
+        $ref: "../primitive.yaml#/Uint64"
+        description: "The slot to which this block corresponds."
       proposer_index:
-        allOf:
-          - $ref: '../primitive.yaml#/Uint64'
-          - description: "Index of validator in validator registry."
+        $ref: '../primitive.yaml#/Uint64'
+        description: "Index of validator in validator registry."
       parent_root:
-        allOf:
-          - $ref: '../primitive.yaml#/Root'
-          - description: "The signing Merkle root of the parent `BeaconBlock`."
+        $ref: '../primitive.yaml#/Root'
+        description: "The signing Merkle root of the parent `BeaconBlock`."
       state_root:
-        allOf:
-          - $ref: '../primitive.yaml#/Root'
-          - description: "The tree hash Merkle root of the `BeaconState` for the `BeaconBlock`."
+        $ref: '../primitive.yaml#/Root'
+        description: "The tree hash Merkle root of the `BeaconState` for the `BeaconBlock`."
 
   BeaconBlockBody:
     type: object
@@ -27,9 +23,8 @@ Altair:
     required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate]
     properties:
       randao_reveal:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: "The RanDAO reveal value provided by the validator."
+        $ref: '../primitive.yaml#/Signature'
+        description: "The RanDAO reveal value provided by the validator."
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:

--- a/types/altair/epoch_participation.yaml
+++ b/types/altair/epoch_participation.yaml
@@ -2,6 +2,5 @@ Altair:
   EpochParticipation:
     type: array
     items:
-      allOf:
-        - $ref: '../primitive.yaml#/Uint8'
+      $ref: '../primitive.yaml#/Uint8'
     maxItems: 1099511627776

--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -75,8 +75,7 @@ Altair:
         description: "Per-validator inactivity scores. New in Altair. Variable length list, maximum 1099511627776 items"
         type: array
         items:
-          allOf:
-            - $ref: "../primitive.yaml#/Uint64"
+          $ref: "../primitive.yaml#/Uint64"
       current_sync_committee:
         $ref: "./sync_committee.yaml#/Altair/SyncCommittee"
       next_sync_committee:

--- a/types/altair/sync_committee.yaml
+++ b/types/altair/sync_committee.yaml
@@ -6,8 +6,7 @@ Altair:
       pubkeys:
         type: array
         items:
-          allOf:
-            - $ref: '../primitive.yaml#/Pubkey'
+          $ref: '../primitive.yaml#/Pubkey'
         minItems: 512
         maxItems: 512
       aggregate_pubkey:
@@ -33,12 +32,10 @@ Altair:
       sync_committee_indices:
         type: array
         items:
-          allOf:
-           - $ref: '../primitive.yaml#/Uint64'
+           $ref: '../primitive.yaml#/Uint64'
       until_epoch:
-        allOf:
-         - $ref: '../primitive.yaml#/Uint64'
-         - description: 'The final epoch (exclusive value) that the specified validator requires the subscription for.'
+        $ref: '../primitive.yaml#/Uint64'
+        description: 'The final epoch (exclusive value) that the specified validator requires the subscription for.'
          
   SignedContributionAndProof:
     type: object
@@ -54,9 +51,8 @@ Altair:
     required: [aggregator_index, selection_proof, contribution]
     properties:
       aggregator_index:
-        allOf:
-          - $ref: "../primitive.yaml#/Uint64"
-          - description: "Index of validator in validator registry."
+        $ref: "../primitive.yaml#/Uint64"
+        description: "Index of validator in validator registry."
       selection_proof:
         $ref: '../primitive.yaml#/Signature'
       contribution:
@@ -67,43 +63,35 @@ Altair:
     required: [slot, beacon_block_root, subcommittee_index, aggregation_bits, signature]
     properties:
       slot:
-        allOf:
-          - $ref: "../primitive.yaml#/Uint64"
-          - description: "The slot at which the validator is providing a sync committee contribution."
+        $ref: "../primitive.yaml#/Uint64"
+        description: "The slot at which the validator is providing a sync committee contribution."
       beacon_block_root:
-        allOf:
-          - $ref: '../primitive.yaml#/Root'
-          - description: "Block root for this contribution."
+        $ref: '../primitive.yaml#/Root'
+        description: "Block root for this contribution."
       subcommittee_index:
-        allOf:
-          - $ref: '../primitive.yaml#/Uint64'
-          - description: 'The index of the subcommittee that the contribution pertains to.'
+        $ref: '../primitive.yaml#/Uint64'
+        description: 'The index of the subcommittee that the contribution pertains to.'
       aggregation_bits:
-        allOf:
-          - description: 'A bit is set if a signature from the validator at the corresponding index in the subcommittee is present in the aggregate `signature`.'
-          - $ref: "../primitive.yaml#/Bitvector"
-          - example: "0xffffffffffffffffffffffffffffffff"
+        description: 'A bit is set if a signature from the validator at the corresponding index in the subcommittee is present in the aggregate `signature`.'
+        $ref: "../primitive.yaml#/Bitvector"
+        example: "0xffffffffffffffffffffffffffffffff"
       signature:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: 'Signature by the validator(s) over the block root of `slot`'
+        $ref: '../primitive.yaml#/Signature'
+        description: 'Signature by the validator(s) over the block root of `slot`'
   ValidatorsByIndex:
     type: array
     items:
-      allOf:
-        - $ref: '../primitive.yaml#/Uint64'
+      $ref: '../primitive.yaml#/Uint64'
   SyncCommitteeByValidatorIndices:
     type: object
     required: [validators, validator_aggregates]
     properties:
       validators:
-        allOf:
-         - $ref: '#/Altair/ValidatorsByIndex'
-         - description: 'all of the validator indices in the current sync committee'
+        $ref: '#/Altair/ValidatorsByIndex'
+        description: 'all of the validator indices in the current sync committee'
       validator_aggregates:
         type: array
         items:
-          allOf:
-            - $ref: '#/Altair/ValidatorsByIndex'
-            - description: 'Subcommittee slices of the current sync committee'
+          $ref: '#/Altair/ValidatorsByIndex'
+          description: 'Subcommittee slices of the current sync committee'
 

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -7,8 +7,7 @@ DepositSnapshotResponse:
     finalized:
       type: array
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
       minItems: 3
       maxItems: 3
     deposit_root:
@@ -25,13 +24,11 @@ ValidatorResponse:
   required: [index, balance, status, validator]
   properties:
     index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of validator in validator registry."
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
     balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Current validator balance in gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Current validator balance in gwei."
     status:
       $ref: "#/ValidatorStatus"
     validator:
@@ -42,13 +39,11 @@ ValidatorBalanceResponse:
   required: [index, balance]
   properties:
     index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of validator in validator registry."
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
     balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Current validator balance in gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Current validator balance in gwei."
 
 ValidatorStatus:
   description: |
@@ -74,9 +69,8 @@ Committee:
   required: [index, slot, validators]
   properties:
     index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: Committee index at a slot
+      $ref: './primitive.yaml#/Uint64'
+      description: Committee index at a slot
     slot:
       $ref: './primitive.yaml#/Uint64'
 

--- a/types/attestation.yaml
+++ b/types/attestation.yaml
@@ -9,9 +9,8 @@ IndexedAttestation:
       items:
         $ref: "./primitive.yaml#/Uint64"
     signature:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "The BLS signature of the `IndexedAttestation`, created by the validator of the attestation."
+      $ref: './primitive.yaml#/Signature'
+      description: "The BLS signature of the `IndexedAttestation`, created by the validator of the attestation."
     data:
       $ref: './attestation.yaml#/AttestationData'
 
@@ -24,9 +23,8 @@ Attestation:
       $ref: "./primitive.yaml#/BitList"
       description: "Attester aggregation bits."
     signature:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "BLS aggregate signature."
+      $ref: './primitive.yaml#/Signature'
+      description: "BLS aggregate signature."
     data:
       $ref: './attestation.yaml#/AttestationData'
 
@@ -55,9 +53,8 @@ AttestationData:
     index:
       $ref: "./primitive.yaml#/Uint64"
     beacon_block_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "LMD GHOST vote."
+      $ref: './primitive.yaml#/Root'
+      description: "LMD GHOST vote."
     source:
       $ref: "./misc.yaml#/Checkpoint"
     target:

--- a/types/bellatrix/block.yaml
+++ b/types/bellatrix/block.yaml
@@ -6,9 +6,8 @@ Bellatrix:
     required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate]
     properties:
       randao_reveal:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: "The RanDAO reveal value provided by the validator."
+        $ref: '../primitive.yaml#/Signature'
+        description: "The RanDAO reveal value provided by the validator."
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:

--- a/types/block.yaml
+++ b/types/block.yaml
@@ -4,21 +4,17 @@ BeaconBlockCommon:
   required: [slot, proposer_index, parent_root, state_root]
   properties:
     slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The slot to which this block corresponds."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The slot to which this block corresponds."
     proposer_index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of validator in validator registry."
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
     parent_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The signing merkle root of the parent `BeaconBlock`."
+      $ref: './primitive.yaml#/Root'
+      description: "The signing merkle root of the parent `BeaconBlock`."
     state_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The tree hash merkle root of the `BeaconState` for the `BeaconBlock`."
+      $ref: './primitive.yaml#/Root'
+      description: "The tree hash merkle root of the `BeaconState` for the `BeaconBlock`."
 
 BeaconBlockBody:
   type: object
@@ -26,9 +22,8 @@ BeaconBlockBody:
   required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits]
   properties:
     randao_reveal:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "The RanDAO reveal value provided by the validator."
+      $ref: './primitive.yaml#/Signature'
+      description: "The RanDAO reveal value provided by the validator."
     eth1_data:
       $ref: './eth1.yaml#/Eth1Data'
     graffiti:
@@ -83,9 +78,8 @@ BeaconBlockHeader:
       required: [body_root]
       properties:
         body_root:
-          allOf:
-            - $ref: './primitive.yaml#/Root'
-            - description: "The tree hash merkle root of the `BeaconBlockBody` for the `BeaconBlock`"
+          $ref: './primitive.yaml#/Root'
+          description: "The tree hash merkle root of the `BeaconBlockBody` for the `BeaconBlock`"
 
 SignedBeaconBlockHeader:
   type: object

--- a/types/capella/block.yaml
+++ b/types/capella/block.yaml
@@ -6,9 +6,8 @@ Capella:
     required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate, bls_to_execution_changes]
     properties:
       randao_reveal:
-        allOf:
-          - $ref: '../primitive.yaml#/Signature'
-          - description: "The RanDAO reveal value provided by the validator."
+          $ref: '../primitive.yaml#/Signature'
+          description: "The RanDAO reveal value provided by the validator."
       eth1_data:
         $ref: '../eth1.yaml#/Eth1Data'
       graffiti:

--- a/types/deposit.yaml
+++ b/types/deposit.yaml
@@ -7,8 +7,7 @@ Deposit:
       type: array
       description: "Branch in the deposit tree."
       items:
-        allOf:
-          - $ref: './primitive.yaml#/Root'
+        $ref: './primitive.yaml#/Root'
       minItems: 32
       maxItems: 32
     data:
@@ -21,14 +20,11 @@ DepositData:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     withdrawal_credentials:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The withdrawal credentials."
+      $ref: './primitive.yaml#/Root'
+      description: "The withdrawal credentials."
     amount:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Amount in Gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Amount in Gwei."
     signature:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "Container self-signature."
+      $ref: './primitive.yaml#/Signature'
+      description: "Container self-signature."

--- a/types/eth1.yaml
+++ b/types/eth1.yaml
@@ -4,14 +4,11 @@ Eth1Data:
   required: [deposit_root, deposit_count, block_hash]
   properties:
     deposit_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "Root of the deposit tree."
+      $ref: './primitive.yaml#/Root'
+      description: "Root of the deposit tree."
     deposit_count:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Total number of deposits."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Total number of deposits."
     block_hash:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "Ethereum 1.x block hash."
+      $ref: './primitive.yaml#/Root'
+      description: "Ethereum 1.x block hash."

--- a/types/fork_choice.yaml
+++ b/types/fork_choice.yaml
@@ -4,17 +4,14 @@ Node:
   required: [slot, block_root, parent_root, justified_epoch, finalized_epoch, weight, validity, execution_block_hash]
   properties:
     slot:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "The slot to which this block corresponds."
+      $ref: './primitive.yaml#/Uint64'
+      description: "The slot to which this block corresponds."
     block_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The signing merkle root of the `BeaconBlock`."
+      $ref: './primitive.yaml#/Root'
+      description: "The signing merkle root of the `BeaconBlock`."
     parent_root:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The signing merkle root of the parent `BeaconBlock`."
+      $ref: './primitive.yaml#/Root'
+      description: "The signing merkle root of the parent `BeaconBlock`."
     justified_epoch:
       $ref: './primitive.yaml#/Uint64'
     finalized_epoch:
@@ -25,9 +22,8 @@ Node:
       type: string
       enum: [valid, invalid, optimistic]
     execution_block_hash:
-      allOf:
-        - $ref: './primitive.yaml#/Root'
-        - description: "The `block_hash` from the `execution_payload` of the `BeaconBlock`"
+      $ref: './primitive.yaml#/Root'
+      description: "The `block_hash` from the `execution_payload` of the `BeaconBlock`"
     extra_data:
       $ref: '#/ExtraData'
 

--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -9,16 +9,14 @@ NetworkIdentity:
     p2p_addresses:
       type: array
       items:
-        allOf:
-          - $ref: "./p2p.yaml#/Multiaddr"
-          - description: "Node's addresses on which eth2 RPC requests are served. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
+        $ref: "./p2p.yaml#/Multiaddr"
+        description: "Node's addresses on which eth2 RPC requests are served. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
     discovery_addresses:
       type: array
       items:
-        allOf:
-          - $ref: "./p2p.yaml#/Multiaddr"
-          - description: "Node's addresses on which is listening for discv5 requests. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
-          - example: "/ip4/7.7.7.7/udp/30303/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
+        $ref: "./p2p.yaml#/Multiaddr"
+        description: "Node's addresses on which is listening for discv5 requests. [Read more](https://docs.libp2p.io/reference/glossary/#multiaddr)"
+        example: "/ip4/7.7.7.7/udp/30303/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
     metadata:
       $ref: "./p2p.yaml#/MetaData"
 
@@ -28,19 +26,16 @@ MetaData:
   required: [seq_number, attnets]
   properties:
     seq_number:
-      allOf:
-        - description: "Uint64 starting at 0 used to version the node's metadata. If any other field in the local MetaData changes, the node MUST increment seq_number by 1."
-        - $ref: "./primitive.yaml#/Uint64"
+      description: "Uint64 starting at 0 used to version the node's metadata. If any other field in the local MetaData changes, the node MUST increment seq_number by 1."
+      $ref: "./primitive.yaml#/Uint64"
     attnets:
-      allOf:
-        - description: "Bitvector representing the node's persistent attestation subnet subscriptions."
-        - $ref: "./primitive.yaml#/Bitvector"
-        - example: "0x0000000000000000"
+      description: "Bitvector representing the node's persistent attestation subnet subscriptions."
+      $ref: "./primitive.yaml#/Bitvector"
+      example: "0x0000000000000000"
     syncnets:
-      allOf:
-        - description: "Bitvector representing the node's sync committee subnet subscriptions. This metadata is not present in phase0, but will be present in Altair."
-        - $ref: "./primitive.yaml#/Bitvector"
-        - example: "0x0f"
+      description: "Bitvector representing the node's sync committee subnet subscriptions. This metadata is not present in phase0, but will be present in Altair."
+      $ref: "./primitive.yaml#/Bitvector"
+      example: "0x0f"
 
 Peer:
   type: object
@@ -53,9 +48,8 @@ Peer:
         - type: "null"
         - $ref: "./p2p.yaml#/ENR"
     last_seen_p2p_address:
-      allOf:
-        - $ref: "./p2p.yaml#/Multiaddr"
-        - description: Multiaddrs used in last peer connection.
+      $ref: "./p2p.yaml#/Multiaddr"
+      description: Multiaddrs used in last peer connection.
     state:
       $ref: "./p2p.yaml#/PeerConnectionState"
     direction:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -18,10 +18,9 @@ Version:
   example: "Lighthouse/v0.1.5 (Linux x86_64)"
 
 GenesisTime:
-  allOf:
-    - $ref: "./primitive.yaml#/Uint64"
-    - example: "1590832934"
-    - description: "The genesis_time configured for the beacon node, which is the unix time in seconds at which the Eth2.0 chain began."
+  $ref: "./primitive.yaml#/Uint64"
+  example: "1590832934"
+  description: "The genesis_time configured for the beacon node, which is the unix time in seconds at which the Eth2.0 chain began."
 
 Wei:
   $ref: "./primitive.yaml#/Uint256"
@@ -42,21 +41,18 @@ Int64:
   example: "1"
 
 DependentRoot:
-  allOf:
-    - $ref: "./primitive.yaml#/Root"
-    - description: "The block root that this response is dependent on."
+  $ref: "./primitive.yaml#/Root"
+  description: "The block root that this response is dependent on."
 
 ExecutionOptimistic:
-  allOf:
-    - type: boolean
-    - example: false
-    - description: "True if the response references an unverified execution payload. Optimistic information may be invalidated at a later time. If the field is not present, assume the False value."
+  type: boolean
+  example: false
+  description: "True if the response references an unverified execution payload. Optimistic information may be invalidated at a later time. If the field is not present, assume the False value."
 
 Finalized:
-  allOf:
-    - type: boolean
-    - example: false
-    - description: "True if the response references the finalized history of the chain, as determined by fork choice. If the field is not present, additional calls are necessary to compare the epoch of the requested information with the finalized checkpoint."
+  type: boolean
+  example: false
+  description: "True if the response references the finalized history of the chain, as determined by fork choice. If the field is not present, additional calls are necessary to compare the epoch of the requested information with the finalized checkpoint."
 
 Root:
   type: string

--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -7,15 +7,13 @@ SyncCommitteeRewards:
     required: [validator_index, reward]
     properties:
       validator_index:
-        allOf:
-          - $ref: "./primitive.yaml#/Uint64"
-          - example: "0"
-          - description: "one entry for every validator participating in the sync committee"
+        $ref: "./primitive.yaml#/Uint64"
+        example: "0"
+        description: "one entry for every validator participating in the sync committee"
       reward:
-        allOf:
-          - $ref: "./primitive.yaml#/Int64"
-          - example: "2000"
-          - description: "sync committee reward in gwei for the validator"
+        $ref: "./primitive.yaml#/Int64"
+        example: "2000"
+        description: "sync committee reward in gwei for the validator"
 
 AttestationsRewards:
   type: object
@@ -37,35 +35,29 @@ AttestationRewards:
   required: [validator_index, head, target, source, inactivity]
   properties:
       validator_index:
-        allOf:
-          - $ref: "./primitive.yaml#/Uint64"
-          - example: "0"
-          - description: "one entry for every validator based on their attestations in the epoch"
+        $ref: "./primitive.yaml#/Uint64"
+        example: "0"
+        description: "one entry for every validator based on their attestations in the epoch"
       head:
-        allOf:
-          - $ref: "./primitive.yaml#/Int64"
-          - example: "2000"
-          - description: "attester's reward for head vote in gwei"
+        $ref: "./primitive.yaml#/Int64"
+        example: "2000"
+        description: "attester's reward for head vote in gwei"
       target:
-        allOf:
-          - $ref: "./primitive.yaml#/Int64"
-          - example: "2000"
-          - description: "attester's reward for target vote in gwei"
+        $ref: "./primitive.yaml#/Int64"
+        example: "2000"
+        description: "attester's reward for target vote in gwei"
       source:
-        allOf:
-          - $ref: "./primitive.yaml#/Int64"
-          - example: "4000"
-          - description: "attester's reward for source vote in gwei"
+        $ref: "./primitive.yaml#/Int64"
+        example: "4000"
+        description: "attester's reward for source vote in gwei"
       inclusion_delay:
-        allOf:
-          - $ref: "./primitive.yaml#/Uint64"
-          - example: "2000"
-          - description: "attester's inclusion_delay reward in gwei (phase0 only)"
+        $ref: "./primitive.yaml#/Uint64"
+        example: "2000"
+        description: "attester's inclusion_delay reward in gwei (phase0 only)"
       inactivity:
-        allOf:
-          - $ref: "./primitive.yaml#/Int64"
-          - example: "2000"
-          - description: "attester's inactivity penalty in gwei"
+        $ref: "./primitive.yaml#/Int64"
+        example: "2000"
+        description: "attester's inactivity penalty in gwei"
 
 IdealAttestationRewards:
   type: object
@@ -73,35 +65,29 @@ IdealAttestationRewards:
   required: [effective_balance, head, target, source, inactivity]
   properties:
     effective_balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "1000000000"
-        - description: "validator's effective balance in gwei"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "1000000000"
+      description: "validator's effective balance in gwei"
     head:
-      allOf:
-        - $ref: "./primitive.yaml#/Int64"
-        - example: "2500"
-        - description: "Ideal attester's reward for head vote in gwei"
+      $ref: "./primitive.yaml#/Int64"
+      example: "2500"
+      description: "Ideal attester's reward for head vote in gwei"
     target:
-      allOf:
-        - $ref: "./primitive.yaml#/Int64"
-        - example: "5000"
-        - description: "Ideal attester's reward for target vote in gwei"
+      $ref: "./primitive.yaml#/Int64"
+      example: "5000"
+      description: "Ideal attester's reward for target vote in gwei"
     source:
-      allOf:
-        - $ref: "./primitive.yaml#/Int64"
-        - example: "5000"
-        - description: "Ideal attester's reward for source vote in gwei"
+      $ref: "./primitive.yaml#/Int64"
+      example: "5000"
+      description: "Ideal attester's reward for source vote in gwei"
     inclusion_delay:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "5000"
-        - description: "Ideal attester's inclusion_delay reward in gwei (phase0 only)"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "5000"
+      description: "Ideal attester's inclusion_delay reward in gwei (phase0 only)"
     inactivity:
-      allOf:
-        - $ref: "./primitive.yaml#/Int64"
-        - example: "5000"
-        - description: "Ideal attester's inactivity penalty in gwei"
+      $ref: "./primitive.yaml#/Int64"
+      example: "5000"
+      description: "Ideal attester's inactivity penalty in gwei"
 
 BlockRewards:
   type: object
@@ -109,32 +95,26 @@ BlockRewards:
   required: [proposer_index, total, attestations, sync_aggregate, proposer_slashings, attester_slashings]
   properties:
     proposer_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "123"
-        - description: "proposer of the block, the proposer index who receives these rewards"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "123"
+      description: "proposer of the block, the proposer index who receives these rewards"
     total:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "123"
-        - description: "total block reward in gwei, equal to attestations + sync_aggregate + proposer_slashings + attester_slashings"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "123"
+      description: "total block reward in gwei, equal to attestations + sync_aggregate + proposer_slashings + attester_slashings"
     attestations:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "123"
-        - description: "block reward component due to included attestations in gwei"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "123"
+      description: "block reward component due to included attestations in gwei"
     sync_aggregate:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "123"
-        - description: "block reward component due to included sync_aggregate in gwei"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "123"
+      description: "block reward component due to included sync_aggregate in gwei"
     proposer_slashings:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "123"
-        - description: "block reward component due to included proposer_slashings in gwei"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "123"
+      description: "block reward component due to included proposer_slashings in gwei"
     attester_slashings:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - example: "123"
-        - description: "block reward component due to included attester_slashings in gwei"
+      $ref: "./primitive.yaml#/Uint64"
+      example: "123"
+      description: "block reward component due to included attester_slashings in gwei"

--- a/types/selection.yaml
+++ b/types/selection.yaml
@@ -3,35 +3,28 @@ BeaconCommitteeSelection:
   required: [validator_index, slot, selection_proof]
   properties:
     validator_index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of the validator"
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of the validator"
     slot:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "The slot at which a validator is assigned to attest"
+      $ref: './primitive.yaml#/Uint64'
+      description: "The slot at which a validator is assigned to attest"
     selection_proof:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "The `slot_signature` calculated by the validator for the upcoming attestation slot"
+      $ref: './primitive.yaml#/Signature'
+      description: "The `slot_signature` calculated by the validator for the upcoming attestation slot"
 
 SyncCommitteeSelection:
   type: object
   required: [validator_index, slot, subcommittee_index, selection_proof]
   properties:
     validator_index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "Index of the validator"
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of the validator"
     slot:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "The slot at which validator is assigned to produce a sync committee contribution"
+      $ref: './primitive.yaml#/Uint64'
+      description: "The slot at which validator is assigned to produce a sync committee contribution"
     subcommittee_index:
-      allOf:
-        - $ref: './primitive.yaml#/Uint64'
-        - description: "SubcommitteeIndex to which the validator is assigned"
+      $ref: './primitive.yaml#/Uint64'
+      description: "SubcommitteeIndex to which the validator is assigned"
     selection_proof:
-      allOf:
-        - $ref: './primitive.yaml#/Signature'
-        - description: "The `slot_signature` calculated by the validator for the upcoming sync committee slot"
+      $ref: './primitive.yaml#/Signature'
+      description: "The `slot_signature` calculated by the validator for the upcoming sync committee slot"

--- a/types/validator.yaml
+++ b/types/validator.yaml
@@ -5,33 +5,27 @@ Validator:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     withdrawal_credentials:
-      allOf:
-        - $ref: "./primitive.yaml#/Root"
-        - description: "Root of withdrawal credentials"
+      $ref: "./primitive.yaml#/Root"
+      description: "Root of withdrawal credentials"
     effective_balance:
-      allOf:
-        - $ref: "./primitive.yaml#/Gwei"
-        - description: "Balance at stake in Gwei."
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Balance at stake in Gwei."
     slashed:
       type: boolean
       example: false
       description: "Was validator slashed (not longer active)."
     activation_eligibility_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "When criteria for activation were met."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "When criteria for activation were met."
     activation_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Epoch when validator activated. 'FAR_FUTURE_EPOCH' if not activated"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Epoch when validator activated. 'FAR_FUTURE_EPOCH' if not activated"
     exit_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Epoch when validator exited. 'FAR_FUTURE_EPOCH' if not exited."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Epoch when validator exited. 'FAR_FUTURE_EPOCH' if not exited."
     withdrawable_epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "When validator can withdraw or transfer funds. 'FAR_FUTURE_EPOCH' if not defined"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "When validator can withdraw or transfer funds. 'FAR_FUTURE_EPOCH' if not defined"
 
 AttesterDuty:
   type: object
@@ -40,29 +34,23 @@ AttesterDuty:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     validator_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of validator in validator registry"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of validator in validator registry"
     committee_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The committee index"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The committee index"
     committee_length:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Number of validators in committee"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Number of validators in committee"
     committees_at_slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Number of committees at the provided slot"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Number of committees at the provided slot"
     validator_committee_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of validator in committee"
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of validator in committee"
     slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The slot at which the validator must attest."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The slot at which the validator must attest."
 
 ProposerDuty:
   type: object
@@ -71,13 +59,11 @@ ProposerDuty:
     pubkey:
       $ref: './primitive.yaml#/Pubkey'
     validator_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of validator in validator registry."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of validator in validator registry."
     slot:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "The slot at which the validator must propose block."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "The slot at which the validator must propose block."
 
 Altair:
   SyncDuty:
@@ -87,9 +73,8 @@ Altair:
       pubkey:
         $ref: './primitive.yaml#/Pubkey'
       validator_index:
-        allOf:
-          - $ref: "./primitive.yaml#/Uint64"
-          - description: "Index of validator in validator registry."
+        $ref: "./primitive.yaml#/Uint64"
+        description: "Index of validator in validator registry."
       validator_sync_committee_indices:
         type: array
         description: "The indices of the validator in the sync committee."

--- a/types/voluntary_exit.yaml
+++ b/types/voluntary_exit.yaml
@@ -4,13 +4,11 @@ VoluntaryExit:
   required: [epoch, validator_index]
   properties:
     epoch:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Minimum epoch for processing exit."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Minimum epoch for processing exit."
     validator_index:
-      allOf:
-        - $ref: "./primitive.yaml#/Uint64"
-        - description: "Index of the exiting validator."
+      $ref: "./primitive.yaml#/Uint64"
+      description: "Index of the exiting validator."
 
 SignedVoluntaryExit:
   type: object


### PR DESCRIPTION
A number of `Schema` and `Response` `$ref`s embed `description` and `example` in a way that is not supported by the openapi spec (relying on an incorrect `allOf` indirection).

Starting with [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/pull/2181) `description` can be overridden at the `$ref` level.
`example` can be defined at the `Response` level, fixing most issues. Some others were duplicates or irrelevant.

Note that some components were already leveraging this syntax, so this PR merely aligns on a single syntax. This also reduces the validation and error messages complexity.

I also validated that `example` still show up in the swagger UI after this change.

requires https://github.com/ethereum/beacon-APIs/pull/409