### PR TITLE
fix: restore ethereum logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,10 @@
     <link rel="stylesheet" type="text/css" href="./dist/swagger-ui.css" >
     <link rel="stylesheet" type="text/css" href="./dist/theme-material.css" >
     <style>
-      .topbar-wrapper img[alt="Swagger UI"] {
+      .swagger-ui .topbar-wrapper a {
         content: url("./assets/ethereum_logo.png");
         height: 68px; /* Width of new image */
+        max-width: 40px;
       }
     </style>
     <link rel="icon" type="image/png" href="./dist/favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
#414 broke the ethereum UI logo. This restores it.

**currently deployed**

<img width="1517" alt="Capture d’écran 2024-01-17 à 16 42 48" src="https://github.com/ethereum/beacon-APIs/assets/359723/da645043-46fc-43b4-a843-221edd83d43b">


**with this PR**
<img width="1596" alt="Capture d’écran 2024-01-17 à 16 42 38" src="https://github.com/ethereum/beacon-APIs/assets/359723/b7582c3d-d873-4ab0-ad7f-d7e1201a8464">

