### PR TITLE
Update info.version for v2.5.0 release

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -21,7 +21,7 @@ info:
 
     Note that it is possible for a field to be added to an endpoint's data or metadata without an increase in the version number.
 
-  version: "Dev - Ethereum Proof-of-Stake Consensus Specification v1.4.0-beta.1"
+  version: "v2.5.0 - Ethereum Proof-of-Stake Consensus Specification v1.4.0"
   contact:
     name: Ethereum Github
     url: https://github.com/ethereum/beacon-apis/issues


### PR DESCRIPTION
Bump version to 2.5.0 to start release process.

Based on https://github.com/ethereum/beacon-APIs/compare/v2.4.2...master there are no breaking changes.