### PR TITLE
Add metadata fields to getBlobSidecars response

### DIFF
--- a/apis/beacon/blob_sidecars/blob_sidecars.yaml
+++ b/apis/beacon/blob_sidecars/blob_sidecars.yaml
@@ -26,6 +26,10 @@ get:
   responses:
     "200":
       description: "Successful response"
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+          required: false
       content:
         application/json:
           schema:
@@ -33,6 +37,14 @@ get:
             type: object
             required: [data]
             properties:
+              version:
+                type: string
+                enum: [phase0, altair, bellatrix, capella, deneb]
+                example: "deneb"
+              execution_optimistic:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
               data:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Deneb.BlobSidecars"
         application/octet-stream:


### PR DESCRIPTION
As noted in https://github.com/ethereum/beacon-APIs/issues/439 and after further [discussion on discord](https://discord.com/channels/595666850260713488/1227937241427611658), the rough consensus seems to be to add those metadata fields without bumping the api version, but to make them optional for now until all clients have updated their implementation.

Closes https://github.com/ethereum/beacon-APIs/issues/439