### PR TITLE
Clarify use of 206 status code for node health.

### DIFF
--- a/apis/node/health.yaml
+++ b/apis/node/health.yaml
@@ -17,7 +17,7 @@ get:
     "200":
       description: Node is ready
     "206":
-      description: Node is syncing but can serve incomplete data
+      description: Either the consensus node is syncing, or its execution node is optimistic, so data served may be incorrect
     "400":
       description: Invalid syncing status code
     "503":

--- a/apis/node/health.yaml
+++ b/apis/node/health.yaml
@@ -17,7 +17,7 @@ get:
     "200":
       description: Node is ready
     "206":
-      description: Either the consensus node is syncing, or its execution node is optimistic, so data served may be incorrect
+      description: Either the beacon node is syncing, or its execution node is optimistic, so data served may be incorrect
     "400":
       description: Invalid syncing status code
     "503":


### PR DESCRIPTION
The 206 return code for the node health endpoint does not take into account the situation where the consensus node may be synced by the execution node is optimistic.  Clarify that this situation should return the 206 status code.