### PR TITLE
Fix the blob encoding type

### DIFF
--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -127,7 +127,7 @@ Blob:
   type: string
   format: hex
   pattern: "^0x[a-fA-F0-9]{262144}$"
-  description: "A blob is `FIELD_ELEMENTS_PER_BLOB * size_of(BLSFieldElement) = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded Blob as defined in Deneb"
+  description: "A blob is `FIELD_ELEMENTS_PER_BLOB * size_of(BLSFieldElement) = 4096 * 32 = 131072` bytes (`DATA`) representing a Blob as defined in Deneb"
 
 KZGCommitment:
   type: string


### PR DESCRIPTION
The blobs returned from the beacon-apis are the raw bytes not encoded into ssz. 

Mentioning it as SSZ encoded cause confusion to decode the output from the API e.g. `ssz.Blob.decode(api_response)` which will not match with the actual blobs. 

Some reference: 

https://github.com/ChainSafe/lodestar/blob/ae984f0f6079f78c2445f36ae2ac09c9e868197e/packages/types/src/deneb/types.ts#L8
