### PR TITLE
Improve the schema for skip_randao_verification flag type

### DIFF
--- a/apis/validator/blinded_block.yaml
+++ b/apis/validator/blinded_block.yaml
@@ -33,14 +33,7 @@ get:
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Graffiti'
     - name: skip_randao_verification
-      in: query
-      required: false
-      description: |
-        Skip verification of the `randao_reveal` value. If this flag is set then the
-        `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter
-        is a flag and does not take a value.
-      schema: {}
-      allowEmptyValue: true
+      $ref: '../../beacon-node-oapi.yaml#/components/parameters/SkipRandaoVerification'
   responses:
     "200":
       description: Success response

--- a/apis/validator/block.v2.yaml
+++ b/apis/validator/block.v2.yaml
@@ -30,14 +30,7 @@ get:
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Graffiti'
     - name: skip_randao_verification
-      in: query
-      required: false
-      description: |
-        Skip verification of the `randao_reveal` value. If this flag is set then the
-        `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter
-        is a flag and does not take a value.
-      schema: {}
-      allowEmptyValue: true
+      $ref: '../../beacon-node-oapi.yaml#/components/parameters/SkipRandaoVerification'
   responses:
     "200":
       description: Success response

--- a/apis/validator/block.v3.yaml
+++ b/apis/validator/block.v3.yaml
@@ -35,14 +35,7 @@ get:
       schema:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/Graffiti'
     - name: skip_randao_verification
-      in: query
-      required: false
-      description: |
-        Skip verification of the `randao_reveal` value. If this flag is set then the
-        `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter
-        is a flag and does not take a value.
-      schema: {}
-      allowEmptyValue: true
+      $ref: '../../beacon-node-oapi.yaml#/components/parameters/SkipRandaoVerification'
     - name: builder_boost_factor
       in: query
       required: false

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -389,6 +389,8 @@ components:
       $ref: './params/index.yaml#/BlockId'
     BlockRoot:
       $ref: './params/index.yaml#/BlockRoot'
+    SkipRandaoVerification:
+      $ref: './params/index.yaml#/SkipRandaoVerification'
 
   responses:
     InvalidRequest:

--- a/params/index.yaml
+++ b/params/index.yaml
@@ -27,3 +27,16 @@ BlockRoot:
   description: |
     Block root.
     \<hex encoded blockRoot with 0x prefix\>.
+SkipRandaoVerification:
+  name: skip_randao_verification
+  in: query
+  required: false
+  description: |
+    Skip verification of the `randao_reveal` value. If this flag is set then the
+    `randao_reveal` must be set to the point at infinity (`0xc0..00`). 
+    For backward compatibility, this query parameter can be set empty, but recommended to set a correct value when calling. 
+  schema:
+    type: 
+      - boolean      
+      - 'null'
+  allowEmptyValue: true

--- a/params/index.yaml
+++ b/params/index.yaml
@@ -38,5 +38,5 @@ SkipRandaoVerification:
   schema:
     type: 
       - boolean      
-      - 'null'
+      - null
   allowEmptyValue: true

--- a/params/index.yaml
+++ b/params/index.yaml
@@ -36,9 +36,7 @@ SkipRandaoVerification:
     `randao_reveal` must be set to the point at infinity (`0xc0..00`). 
     For backward compatibility, this query parameter can be set empty, but recommended to set a correct value when calling. 
   schema:
-    oneOf: 
-      - type: boolean
-      - type: string
-        minLength: 0
-        maxLength: 0
+    type: string
+    minLength: 0
+    maxLength: 0
   allowEmptyValue: true

--- a/params/index.yaml
+++ b/params/index.yaml
@@ -36,7 +36,9 @@ SkipRandaoVerification:
     `randao_reveal` must be set to the point at infinity (`0xc0..00`). 
     For backward compatibility, this query parameter can be set empty, but recommended to set a correct value when calling. 
   schema:
-    type: 
-      - boolean      
-      - null
+    oneOf: 
+      - type: boolean
+      - type: string
+        minLength: 0
+        maxLength: 0
   allowEmptyValue: true

--- a/params/index.yaml
+++ b/params/index.yaml
@@ -34,7 +34,6 @@ SkipRandaoVerification:
   description: |
     Skip verification of the `randao_reveal` value. If this flag is set then the
     `randao_reveal` must be set to the point at infinity (`0xc0..00`). 
-    For backward compatibility, this query parameter can be set empty, but recommended to set a correct value when calling. 
   schema:
     type: string
     minLength: 0


### PR DESCRIPTION
There are few issues the way current spec defined the `skip_randao_verification` parameter. As of my understanding that's the only boolean type path parameter defined in the spec, but we should follow the approach in this fix for any future case as well. 

### Problem
The current spec says if you want to set this flag, don't set value. Which is not semantically possible as it's a query parameter, so eventually any value which is not set is considered as **empty string** from most HTTP request parser. 

Flags implies it's a boolean value, so eventually the spec says if you want to set this flag to **true** set it to am **empty string** value. Which is logically considered **false** on different dynamic programming languages, or in dynamic execution of a static languages. e.g. 

JS
```js
"" ? true : false; // false 
```
Python 
```python
 True if "" else False # False
```

This causes compatibility issues among different clients. 

https://github.com/ChainSafe/lodestar/issues/6637
Was compatibility issue with Lighthouse as well. 


### Solution 

The solution is to set a proper type and make sure the value for this parameter is sent properly. This will be a breaking change onward, but to keep old Validator Clients running, we should accept **empty string** as **true** boolean value. 

This backward compatibility check should be removed in upcoming hard fork, where appropriate. 


### Verification 
The behavior for the change in schema can be verified on the following link:
https://runkit.com/nazarhussain/661d0724d9a8fd0008526ae7
