### PR TITLE
Add getAggregatedAttestationV2 to support EIP-7549

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ There are likely to be descriptions etc outside of the list below, but new query
 
 | Endpoint                                                                                                            | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
 |---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
+| [#447](https://github.com/ethereum/beacon-APIs/pull/447) `GET /eth/v2/validator/aggregate_attestation` added         |                                                  |                                                   |                                                    |                                                 |                                           |
 
 
 The Following are no longer in the Standard API, removed since the latest version.

--- a/apis/validator/aggregate_attestation.v2.yaml
+++ b/apis/validator/aggregate_attestation.v2.yaml
@@ -1,0 +1,50 @@
+get:
+  operationId: "getAggregatedAttestationV2"
+  summary: "Get aggregated attestation"
+  description: |
+    Aggregates all attestations matching given attestation data root, slot and committee index.
+
+    A 503 error must be returned if the block identified by the response
+    `beacon_block_root` is optimistic (i.e. the aggregated attestation attests
+    to a block that has not been fully verified by an execution engine).
+
+    A 404 error must be returned if no attestation is available for the requested
+    `attestation_data_root`.
+  tags:
+    - ValidatorRequiredApi
+    - Validator
+  parameters:
+    - name: attestation_data_root
+      in: query
+      required: true
+      description: "HashTreeRoot of AttestationData that validator wants aggregated"
+      schema:
+        $ref: '../../beacon-node-oapi.yaml#/components/schemas/Root'
+    - name: slot
+      in: query
+      required: true
+      schema:
+        $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+    - name: committee_index
+      in: query
+      required: true
+      schema:
+        $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+  responses:
+    "200":
+      description: "Returns aggregated `Attestation` object with same `AttestationData` root, slot and committee index."
+      content:
+        application/json:
+          schema:
+            title: GetAggregatedAttestationV2Response
+            type: object
+            required: [data]
+            properties:
+              data:
+                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Electra.Attestation'
+    "400":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "404":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/NotFound'
+    "500":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/aggregate_attestation.v2.yaml
+++ b/apis/validator/aggregate_attestation.v2.yaml
@@ -33,12 +33,15 @@ get:
   responses:
     "200":
       description: "Returns aggregated `Attestation` object with same `AttestationData` root, slot and committee index."
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
       content:
         application/json:
           schema:
             title: GetAggregatedAttestationV2Response
             type: object
-            required: [data]
+            required: [version, data]
             properties:
               version:
                 type: string

--- a/apis/validator/aggregate_attestation.v2.yaml
+++ b/apis/validator/aggregate_attestation.v2.yaml
@@ -40,8 +40,14 @@ get:
             type: object
             required: [data]
             properties:
+              version:
+                type: string
+                enum: [phase0, altair, bellatrix, capella, deneb, electra]
+                example: "phase0"
               data:
-                $ref: '../../beacon-node-oapi.yaml#/components/schemas/Electra.Attestation'
+                anyOf:
+                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Attestation'
+                  - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Electra.Attestation'
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "404":

--- a/apis/validator/aggregate_attestation.yaml
+++ b/apis/validator/aggregate_attestation.yaml
@@ -1,6 +1,7 @@
 get:
   operationId: "getAggregatedAttestation"
   summary: "Get aggregated attestation"
+  deprecated: true
   description: |
     Aggregates all attestations matching given attestation data root and slot.
 

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -180,6 +180,8 @@ paths:
     $ref: "./apis/validator/attestation_data.yaml"
   /eth/v1/validator/aggregate_attestation:
     $ref: "./apis/validator/aggregate_attestation.yaml"
+  /eth/v2/validator/aggregate_attestation:
+    $ref: "./apis/validator/aggregate_attestation.v2.yaml"
   /eth/v1/validator/aggregate_and_proofs:
     $ref: "./apis/validator/aggregate_and_proofs.yaml"
   /eth/v1/validator/beacon_committee_subscriptions:
@@ -371,6 +373,8 @@ components:
       $ref: './types/primitive.yaml#/Blob'
     Deneb.BlobSidecars:
       $ref: './types/deneb/blob_sidecar.yaml#/Deneb/BlobSidecars'
+    Electra.Attestation:
+      $ref: './types/electra/attestation.yaml#/Electra/Attestation'
     Node:
       $ref: './types/fork_choice.yaml#/Node'
     ExtraData:

--- a/types/electra/attestation.yaml
+++ b/types/electra/attestation.yaml
@@ -8,10 +8,10 @@ Electra:
         $ref: "../primitive.yaml#/BitList"
         description: "Attester aggregation bits."
       signature:
-        $ref: '../primitive.yaml#/Signature'
+        $ref: "../primitive.yaml#/Signature"
         description: "BLS aggregate signature."
       data:
-        $ref: '../attestation.yaml#/AttestationData'
+        $ref: "../attestation.yaml#/AttestationData"
       committee_bits:
         $ref: "../primitive.yaml#/Bitvector"
         description: "Committee bits."

--- a/types/electra/attestation.yaml
+++ b/types/electra/attestation.yaml
@@ -2,16 +2,16 @@ Electra:
   Attestation:
     type: object
     description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#attestation) object from the CL spec."
-    required: [aggregation_bits, signature, data, committee_bits]
+    required: [aggregation_bits, data, signature, committee_bits]
     properties:
       aggregation_bits:
         $ref: "../primitive.yaml#/BitList"
         description: "Attester aggregation bits."
+      data:
+        $ref: "../attestation.yaml#/AttestationData"
       signature:
         $ref: "../primitive.yaml#/Signature"
         description: "BLS aggregate signature."
-      data:
-        $ref: "../attestation.yaml#/AttestationData"
       committee_bits:
         $ref: "../primitive.yaml#/Bitvector"
         description: "Committee bits."

--- a/types/electra/attestation.yaml
+++ b/types/electra/attestation.yaml
@@ -1,7 +1,7 @@
 Electra:
   Attestation:
     type: object
-    description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#attestation) object from the CL spec."
+    description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#attestation) object from the CL spec."
     required: [aggregation_bits, data, signature, committee_bits]
     properties:
       aggregation_bits:

--- a/types/electra/attestation.yaml
+++ b/types/electra/attestation.yaml
@@ -1,0 +1,18 @@
+Electra:
+  Attestation:
+    type: object
+    description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/specs/electra/beacon-chain.md#attestation) object from the CL spec."
+    required: [aggregation_bits, signature, data, committee_bits]
+    properties:
+      aggregation_bits:
+        $ref: "../primitive.yaml#/BitList"
+        description: "Attester aggregation bits."
+      signature:
+        $ref: '../primitive.yaml#/Signature'
+        description: "BLS aggregate signature."
+      data:
+        $ref: '../attestation.yaml#/AttestationData'
+      committee_bits:
+        $ref: "../primitive.yaml#/Bitvector"
+        description: "Committee bits."
+        example: "0x0000000000000000000000000000000000000000000000000000000000000001"


### PR DESCRIPTION
`AttestationData` post-electra is committee-indifferent, and thus, the same `attestation_data_root` might be shared across different committees. 

An aggregator is only interested in attestations in its corresponding committee. `getAggregatedAttestationV1` might aggregate attestations from multiple committees since `committee_index` is not in its params. 

This PR adds `getAggregatedAttestationV2` to aggregate attestations given `attestation_data_root` + `slot` + `committee_index`.

Part of #445 

