### PR TITLE
Add validators v2.

### DIFF
--- a/apis/beacon/states/validators.v2.yaml
+++ b/apis/beacon/states/validators.v2.yaml
@@ -1,0 +1,83 @@
+post:
+  operationId: "postStateValidatorsV2"
+  summary: "Get validators from state"
+  description: |
+    Returns filterable list of validators with their index.
+
+    Information will be returned for all indices or public keys that match known validators.  If an index or public key does not
+    match any known validator, no information will be returned but this will not cause an error.  There are no guarantees for the
+    returned data in terms of ordering; both the index and public key are returned for each validator, and can be used to confirm
+    for which inputs a response has been returned.
+  tags:
+    - Beacon
+  parameters:
+    - name: state_id
+      in: path
+      $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
+  requestBody:
+    description: "The lists of validator IDs and statuses to filter on. Either or both may be `null` to signal that no filtering on that attribute is desired."
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: []
+          properties:
+            ids:
+              type: array
+              uniqueItems: true
+              items:
+                description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
+                type: string
+            statuses:
+              type: array
+              uniqueItems: true
+              items:
+                oneOf:
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus'
+                  - enum: ["active", "pending", "exited", "withdrawal"]
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            title: PostStateValidatorsV2Response
+            type: object
+            required: [version, execution_optimistic, finalized, data]
+            properties:
+              version:
+                type: string
+                enum: [ phase0, altair, bellatrix, capella, deneb ]
+                example: "phase0"
+              execution_optimistic:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Finalized"
+              data:
+                type: array
+                items:
+                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorV2Response'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized array of the returned data. Use Accept header to choose this response type"
+    "400":
+      description: "Invalid state or validator ID, or status"
+      content:
+        application/json:
+          schema:
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid state ID: current"
+    "404":
+      description: "State not found"
+      content:
+        application/json:
+          schema:
+            $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 404
+            message: "State not found"
+    "500":
+      $ref: "../../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/beacon/states/validators.v2.yaml
+++ b/apis/beacon/states/validators.v2.yaml
@@ -39,6 +39,9 @@ post:
   responses:
     "200":
       description: Success
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
       content:
         application/json:
           schema:

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -1,6 +1,7 @@
 get:
   operationId: "getStateValidators"
   summary: "Get validators from state"
+  deprecated: true
   description: |
     Returns filterable list of validators with their balance, status and index.
 

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -88,6 +88,7 @@ get:
 post:
   operationId: "postStateValidators"
   summary: "Get validators from state"
+  deprecated: true
   description: |
     Returns filterable list of validators with their balance, status and index.
 

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -71,6 +71,8 @@ paths:
     $ref: "./apis/beacon/states/finality_checkpoints.yaml"
   /eth/v1/beacon/states/{state_id}/validators:
     $ref: "./apis/beacon/states/validators.yaml"
+  /eth/v2/beacon/states/{state_id}/validators:
+    $ref: "./apis/beacon/states/validators.v2.yaml"
   /eth/v1/beacon/states/{state_id}/validators/{validator_id}:
     $ref: "./apis/beacon/states/validator.yaml"
   /eth/v1/beacon/states/{state_id}/validator_balances:
@@ -221,6 +223,8 @@ components:
       $ref: './types/block.yaml#/SignedBeaconBlockHeader'
     ValidatorResponse:
       $ref: './types/api.yaml#/ValidatorResponse'
+    ValidatorV2Response:
+      $ref: './types/api.yaml#/ValidatorV2Response'
     ValidatorBalanceResponse:
       $ref: './types/api.yaml#/ValidatorBalanceResponse'
     ValidatorStatus:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -34,6 +34,19 @@ ValidatorResponse:
     validator:
       $ref: "./validator.yaml#/Validator"
 
+ValidatorV2Response:
+  type: object
+  required: [index, balance, validator]
+  properties:
+    index:
+      $ref: './primitive.yaml#/Uint64'
+      description: "Index of validator in validator registry."
+    balance:
+      $ref: "./primitive.yaml#/Gwei"
+      description: "Current validator balance in gwei."
+    validator:
+      $ref: "./validator.yaml#/Validator"
+
 ValidatorBalanceResponse:
   type: object
   required: [index, balance]


### PR DESCRIPTION
This PR adds a version 2 of the validators API.

The requirement comes from the number of entries in the `Validators` array in state on mainnet.  At time of writing there are over 1.4MM entries, and no plans to reduce this number (there are some options that could reduce the number of active validators, but this doesn't help the array itself).  The JSON returned by v1 of this response is over 600MB in size, which has knock-on effects for both speed of delivery (it takes approximately 5s to send this much data over a 1GB link) and decoding time.  As such, a version of this endpoint that supports SSZ would be useful.

The changes in this endpoint from v1 are:

- allow SSZ as a return encoding type
- remove the `status` item from the per-validator data
- provide the consensus version in the header and JSON metadata

`status` is a text string in the JSON response for v1 of this call, so does not have a canonical mapping to SSZ.  Instead of removing it, other options are to define a mapping similar to an enum, or to provide it as a byte array.  Both come with added complexity or increased data, and the information that it provides can be calculated from the data that is already provided in the validator struct (plus an epoch).

Some open questions around this endpoint:

- should we add an `epoch` metadata field in the returned data to allow recreation of validator states for when the state identifier used as part of this call is non-numeric (`head`, `finalized` etc.)?
- should we remove the `balance` value for each validator?  This value is available from the `validator_balances` endpoint, does it make sense to still duplicate it here?
- could we realistically remove the `index` value for each validator?  The big benefit of doing this would be that the data returned could be a simple array of `Validator` objects, which would remove the need for custom structures when decoding SSZ (and, indeed, JSON).  However, there is a significant downside here in that the index information would no longer be easy to obtain.  Countering that, should we be promoting the use of indices anywhere in the API when it's possible that index reuse will become a thing?
- if we do not return status, should we still allow filtering the requested values by status?