### PR TITLE
Allow to bypass validation checks for `publishBlockV2`

### DIFF
--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -29,6 +29,7 @@ post:
         - **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation
           check immediately before the block is broadcast. If the block is found to be an
           equivocation it fails validation.
+        - **`no_validation`** bypass all validation checks and broadcast the block immediately          
 
         If the block fails the requested level of a validation a 400 status MUST be returned
         immediately and the block MUST NOT be broadcast to the network.

--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -29,7 +29,7 @@ post:
         - **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation
           check immediately before the block is broadcast. If the block is found to be an
           equivocation it fails validation.
-        - **`none`** bypass all validation checks and broadcast the block immediately          
+        - **`none`**: bypass all validation checks and broadcast the block immediately          
 
         If the block fails the requested level of a validation a 400 status MUST be returned
         immediately and the block MUST NOT be broadcast to the network.

--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -29,7 +29,7 @@ post:
         - **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation
           check immediately before the block is broadcast. If the block is found to be an
           equivocation it fails validation.
-        - **`no_validation`** bypass all validation checks and broadcast the block immediately          
+        - **`none`** bypass all validation checks and broadcast the block immediately          
 
         If the block fails the requested level of a validation a 400 status MUST be returned
         immediately and the block MUST NOT be broadcast to the network.

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -28,7 +28,7 @@ post:
         - **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation
           check immediately before the block is broadcast. If the block is found to be an
           equivocation it fails validation.
-        - **`none`** bypass all validation checks and broadcast the block immediately
+        - **`none`**: bypass all validation checks and broadcast the block immediately
 
         If the block fails the requested level of a validation a 400 status MUST be returned
         immediately and the block MUST NOT be broadcast to the network.

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -28,6 +28,7 @@ post:
         - **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation
           check immediately before the block is broadcast. If the block is found to be an
           equivocation it fails validation.
+        - **`no_validation`** bypass all validation checks and broadcast the block immediately
 
         If the block fails the requested level of a validation a 400 status MUST be returned
         immediately and the block MUST NOT be broadcast to the network.

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -28,7 +28,7 @@ post:
         - **`consensus_and_equivocation`**: the same as `consensus`, with an extra equivocation
           check immediately before the block is broadcast. If the block is found to be an
           equivocation it fails validation.
-        - **`no_validation`** bypass all validation checks and broadcast the block immediately
+        - **`none`** bypass all validation checks and broadcast the block immediately
 
         If the block fails the requested level of a validation a 400 status MUST be returned
         immediately and the block MUST NOT be broadcast to the network.

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -83,4 +83,4 @@ Committee:
 BroadcastValidation:
   description: Level of validation that must be applied to a block before it is broadcast.
   type: string
-  enum: [gossip, consensus, consensus_and_equivocation, no_validation]
+  enum: [gossip, consensus, consensus_and_equivocation, none]

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -83,4 +83,4 @@ Committee:
 BroadcastValidation:
   description: Level of validation that must be applied to a block before it is broadcast.
   type: string
-  enum: [gossip, consensus, consensus_and_equivocation]
+  enum: [gossip, consensus, consensus_and_equivocation, no_validation]


### PR DESCRIPTION
When creating blocks locally, most of the gossip checks would have already been covered by the process of creating the block itself (at least in Teku), so it makes sense to add an option to bypass validation checks altogether and publish the block immediately. This way there would be no additional delays (even if small) of broadcasting the block to the network when using `v2` for publishing.