### PR TITLE
Clarify requirement for validator balances body

### DIFF
--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -79,7 +79,7 @@ post:
   description: |
     Returns filterable list of validators balances.
 
-    Balances will be returned for all indices or public key that match known validators. If an index or public key does not
+    Balances will be returned for all indices or public keys that match known validators. If an index or public key does not
     match any known validator, no balance will be returned but this will not cause an error. There are no guarantees for the
     returned data in terms of ordering; the index is returned for each balance, and can be used to confirm for which inputs a
     response has been returned.
@@ -90,8 +90,11 @@ post:
       in: path
       $ref: '../../../beacon-node-oapi.yaml#/components/parameters/StateId'
   requestBody:
-    description: "An array of either hex encoded public key (any bytes48 with 0x prefix) or validator index"
-    required: false
+    description: |
+      Either hex encoded public key (any bytes48 with 0x prefix) or validator index.
+
+      If the supplied list is empty (i.e. the body is `[]`) then balances will be returned for all validators.
+    required: true
     content:
       application/json:
         schema:


### PR DESCRIPTION
Looking at the `validator_balances` endpoint there is some ambiguity around what to do in some cases.  Specifically, for POST to `/eth/v1/beacon/states/head/validator_balances`:

With no body:

- lighthouse returns an error
- lodestar returns an error
- nimbus returns an error
- prysm returns an error
- teku returns all balances

With an empty array in the body:

- lighthouse returns no balances
- lodestar returns no balances
- nimbus returns all balances
- prysm returns all balances
- teku returns all balances

I think that the best balance of attempting to retain existing functionality whilst firming up the spec is to state that no body will return an error, and an empty array will return all balances.  This also ensures that users have a way to obtain all balances easily..