### PR TITLE
Update CI tooling to latest versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         release: ${{fromJson(needs.setup.outputs.releases)}}
     steps:
-      - uses: dsaltares/fetch-gh-release-asset@1.1.0
+      - uses: dsaltares/fetch-gh-release-asset@1.1.2
         with:
-          version: 'tags/${{ matrix.release }}'
-          file: 'beacon-node-oapi.json'
-          target: 'deploy/releases/${{ matrix.release }}/beacon-node-oapi.json'
+          version: "tags/${{ matrix.release }}"
+          file: "beacon-node-oapi.json"
+          target: "deploy/releases/${{ matrix.release }}/beacon-node-oapi.json"
       - name: Save releases (artifact)
         uses: actions/upload-artifact@v3
         with:
@@ -37,8 +37,8 @@ jobs:
     needs: releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm i -g @apidevtools/swagger-cli@4
       - name: Prepare deploy directory
         run: |
@@ -55,7 +55,7 @@ jobs:
       - name: Bundle spec
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
       - name: Publish to Github Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,23 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-    - run: npm i -g @apidevtools/swagger-cli@4 @redocly/cli@1.0.0-beta.111
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm i -g @apidevtools/swagger-cli@4 @redocly/cli@1.19.0
 
-    - name: Lint spec
-      run: redocly lint ./beacon-node-oapi.yaml
+      - name: Lint spec
+        run: redocly lint ./beacon-node-oapi.yaml
 
-    - name: Bundle spec
-      run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
+      - name: Bundle spec
+        run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm i -g @apidevtools/swagger-cli@4
       - name: Bundle yaml spec
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
@@ -18,41 +18,27 @@ jobs:
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: false
-      - name: Upload Yaml Bundle
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./deploy/beacon-node-oapi.yaml
-          asset_name: beacon-node-oapi.yaml
-          asset_content_type: text/x-yaml
-      - name: Upload Json Bundle
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./deploy/beacon-node-oapi.json
-          asset_name: beacon-node-oapi.json
-          asset_content_type: application/json
+          files: |
+            ./deploy/beacon-node-oapi.yaml
+            ./deploy/beacon-node-oapi.json
+          fail_on_unmatched_files: true
       - name: Rollback Release
         if: failure()
-        uses: author/action-rollback@stable
+        uses: author/action-rollback@1.0.4
         with:
           # Using a known release ID
-          id: ${{ steps.create_release.id }}
+          release_id: ${{ steps.create_release.outputs.id }}
           # Using a tag name
           tag: ${{ github.ref }}
-          # Always delete} the tag, even if a release is not associated with it.
-          always_delete_tag: true
+          # Remove the tag if release process failed
+          delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
@@ -34,11 +34,8 @@ jobs:
         if: failure()
         uses: author/action-rollback@1.0.4
         with:
-          # Using a known release ID
           release_id: ${{ steps.create_release.outputs.id }}
-          # Using a tag name
           tag: ${{ github.ref }}
-          # Remove the tag if release process failed
           delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,11 +1,17 @@
 name: Spellcheck
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.29.0
-      name: Spellcheck
+      - uses: actions/checkout@v4
+      - uses: rojopolis/spellcheck-github-actions@0.40.0
+        name: Spellcheck


### PR DESCRIPTION
Update github actions / workflows to use latest versions and swaps out deprecated actions with maintained ones. This also simplifies a few upload / bundling steps.

I have tested all workflows on a forked repo, everything seems to work as before.