### PR TITLE
Add workflow to create pre-releases

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -18,6 +18,11 @@ jobs:
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
       - name: Bundle json spec
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
+      - name: Create Release Notes
+        run: |
+          echo "The following changes are included in this release:" > release-notes.md
+          awk '/^## Development Version/ {flag=1; next} /^## / {flag=0} flag { \
+          if ($0 ~ /\| \[#/) {sub(/^\| /, "- "); sub(/\| .*$/, ""); sub(/[[:space:]]+$/, ""); print}}' CHANGES.md >> release-notes.md
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -26,6 +31,7 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
+          body_path: "release-notes.md"
           draft: false
           prerelease: true
           files: |

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -3,7 +3,7 @@ name: Pre-release
 on:
   push:
     tags:
-      - "v*-alpha.*"
+      - "v*-(alpha|beta|rc).*"
 
 jobs:
   release:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,46 @@
+name: Pre-release
+
+on:
+  push:
+    tags:
+      - "v*-alpha.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm i -g @apidevtools/swagger-cli@4
+      - name: Update Spec version
+        run: "sed -i 's/version: \"Dev/version: \"${{ github.ref_name }}/' ./beacon-node-oapi.yaml"
+      - name: Bundle yaml spec
+        run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
+      - name: Bundle json spec
+        run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: true
+          files: |
+            ./deploy/beacon-node-oapi.yaml
+            ./deploy/beacon-node-oapi.json
+          fail_on_unmatched_files: true
+      - name: Rollback Release
+        if: failure()
+        uses: author/action-rollback@1.0.4
+        with:
+          # Using a known release ID
+          release_id: ${{ steps.create_release.outputs.id }}
+          # Using a tag name
+          tag: ${{ github.ref }}
+          # Remove the tag if release process failed
+          delete_orphan_tag: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -27,7 +27,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
@@ -42,11 +42,8 @@ jobs:
         if: failure()
         uses: author/action-rollback@1.0.4
         with:
-          # Using a known release ID
           release_id: ${{ steps.create_release.outputs.id }}
-          # Using a tag name
           tag: ${{ github.ref }}
-          # Remove the tag if release process failed
           delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-alpha.*"
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "v*"
-      - "!v*-alpha.*"
+      - "!v*-(alpha|beta|rc).*"
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ redocly lint beacon-node-oapi.yaml
 ```
          {url: "./releases/<tag>/beacon-node-oapi.json", name: "<tag>"},
 ```
+
+### Pre-releases
+
+To create a pre-release, simply push a new tag with the suffix `-alpha.x`. The CD will create a github release and upload the bundled spec files.
+
+Pre-releases will not be listed in `index.html` and are intended to allow early testing against the spec.

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -23,6 +23,7 @@ MEV
 PayloadAttributesV
 Gwei
 prev
+pre
 ENR
 enr
 attnets


### PR DESCRIPTION
**Motivation**

This is a proposal for pre-releases of the beacon api spec similar to what's done on the consensus spec. This allows clients to run spec tests earlier in the development cycle.

**Description**

A pre-release can be created by simply pushing a new tag with the suffix `-alpha.x`. The CD will create a github release and upload the bundled spec files.

Pre-releases will not be listed in `index.html` and not show up on the explorer.