### PR TITLE
Fully automate release process

### DIFF
--- a/.github/changes-template.md
+++ b/.github/changes-template.md
@@ -1,0 +1,13 @@
+## Development Version
+
+These endpoints have been added or updated since the last release.
+
+There are likely to be descriptions etc outside of the list below, but new query parameters, changes to headers, new endpoints should be listed.
+
+| Endpoint                                                                                                            | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
+|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
+
+The Following are no longer in the Standard API, removed since the latest version.
+
+| Endpoint                                                                                                 | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
+|----------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -3,7 +3,9 @@ name: Pre-release
 on:
   push:
     tags:
-      - "v*-(alpha|beta|rc).*"
+      - "v*-alpha.*"
+      - "v*-beta.*"
+      - "v*-rc.*"
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,9 @@ on:
   push:
     tags:
       - "v*"
-      - "!v*-(alpha|beta|rc).*"
+      - "!v*-alpha.*"
+      - "!v*-beta.*"
+      - "!v*-rc.*"
 
 jobs:
   release:
@@ -13,10 +15,34 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
       - run: npm i -g @apidevtools/swagger-cli@4
+      - name: Update Spec version
+        run: "sed -i 's/version: \"Dev/version: \"${{ github.ref_name }}/' ./beacon-node-oapi.yaml"
       - name: Bundle yaml spec
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t yaml -o ./deploy/beacon-node-oapi.yaml"
       - name: Bundle json spec
         run: "swagger-cli bundle ./beacon-node-oapi.yaml -r -t json -o ./deploy/beacon-node-oapi.json"
+      - name: Update index.html
+        run: |
+          sed -i "/urls:/a \          {url: \"./releases/${{ github.ref_name }}/beacon-node-oapi.json\", name: \"${{ github.ref_name }}\"}," ./index.html
+      - name: Update Changelog
+        run: |
+          sed -i "s/## Development Version/## ${{ github.ref_name }}/" ./CHANGES.md
+          awk '/# Recent Changes/ {print; print ""; system("cat .github/changes-template.md"); next}1' CHANGES.md > temp && mv temp CHANGES.md
+      - name: Create Release Notes
+        run: |
+          echo "The following changes are included in this release:" > release-notes.md
+          awk '/^## ${{ github.ref_name }}/ {flag=1; next} /^## / {flag=0} flag { \
+          if ($0 ~ /\| \[#/) {sub(/^\| /, "- "); sub(/\| .*$/, ""); sub(/[[:space:]]+$/, ""); print}}' CHANGES.md >> release-notes.md
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Release ${{ github.ref_name }}"
+          branch: release-${{ github.ref_name }}
+          title: "Release ${{ github.ref_name }}"
+          body-path: "release-notes.md"
+          base: master
+          add-paths: index.html,CHANGES.md
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -25,6 +51,7 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
+          body_path: "release-notes.md"
           draft: false
           prerelease: false
           files: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,5 @@
 # Recent Changes
 
-
 ## Development Version
 
 These endpoints have been added or updated since the last release.
@@ -24,7 +23,7 @@ The Following are no longer in the Standard API, removed since the latest versio
 |----------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
 
 
-## Version 2.5.0
+## v2.5.0
 
 These endpoints have been added or updated since the last release.
 
@@ -41,7 +40,7 @@ There are likely to be descriptions etc outside of the list below, but new query
 | [#405](https://github.com/ethereum/beacon-APIs/pull/405) `block_gossip EVENT` added                                 |                                                  | -                                                  |                                                    |                                                 |                                           |
 
 
-## Version 2.4.2
+## v2.4.2
 
 These endpoints have been added or updated since the last release.
 
@@ -53,7 +52,7 @@ There are likely to be descriptions etc outside of the list below, but new query
 | [#339](https://github.com/ethereum/beacon-APIs/pull/339) `POST /eth/v2/validator/*blocks` deprecated                                 |                                                  | v1.14.0                                                  |                                                    |                                                 |                                           |
 
 
-## Version 2.4.1
+## v2.4.1
 
 | Endpoint                                                                                                                                    | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
 |---------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
@@ -70,7 +69,7 @@ There are likely to be descriptions etc outside of the list below, but new query
 | [#327](https://github.com/ethereum/beacon-APIs/pull/327) Increased maximum number of blobs from 4 to 6                        |                                                  | v1.9.0                                                  |                                                    |                                                 |                                           |
 
 
-## Version 2.4.0
+## v2.4.0
 
 __Note__ Clients can add notes about level of support for specific endpoints if there are caveats or aspects not implemented.
 

--- a/README.md
+++ b/README.md
@@ -68,22 +68,23 @@ redocly lint beacon-node-oapi.yaml
 
 ## Releasing
 
-1. Create and push tag
+This repository supports both stable and pre-releases. The version of the next release has to be
+determined based on the changes in `master` branch since the last stable release. It is recommended
+to create a pre-release before releasing a new stable version.
 
-   - Make sure `info.version` in `beacon-node-oapi.yaml` file is updated before tagging.  This will need to be a PR, and will get the release process started.
-   - CD will create github release and upload bundled spec file
+### Stable releases
 
-2. Create a second PR, containing the updated `index.html`. Also change back the `info.version` in `beacon-node-api.yaml` back to `Dev`
+Steps to create a new stable release:
 
-   - The `index.html` file needs a new release entrypoint added to refer to the new release. Find the `urls` field, 
-     and add the new release as the first entry in the list.
-     Entry should be in following format(replace `<tag>` with real tag name from step 1.):
-```
-         {url: "./releases/<tag>/beacon-node-oapi.json", name: "<tag>"},
-```
+- Create and push a tag with the version of the release, e.g. `v3.0.0`
+- CD will create the github release, upload bundled spec files, and open a release PR
+- Review, approve and merge the release PR to `master` branch
 
 ### Pre-releases
 
-To create a pre-release, simply push a new tag with the suffix `-alpha.x`. The CD will create a github release and upload the bundled spec files.
+Steps to create a new pre-release:
+
+- Create and push a tag with the version of the release, e.g. `v3.0.0-alpha.0`
+- CD will create the github release and upload bundled spec files
 
 Pre-releases will not be listed in `index.html` and are intended to allow early testing against the spec.


### PR DESCRIPTION
This PR removes [manual steps](https://github.com/ethereum/beacon-APIs?tab=readme-ov-file#releasing) required to create a new release.

All steps are now handled by the CI after pushing a tag, this includes
- update spec version `info.version` in `beacon-node-oapi.yaml`
- add new entry to `index.html` in the format `{url: "./releases/<tag>/beacon-node-oapi.json", name: "<tag>"},`
- update changelog file (`CHANGES.md`) by moving entries to `## <tag>` section
- create github release and upload bundled spec files
- create release notes from changelog entries