### PR TITLE
Deprecate v1 block publishing

### DIFF
--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -3,6 +3,7 @@ post:
     - Beacon
     - ValidatorRequiredApi
   summary: "Publish a signed block."
+  deprecated: true
   operationId: "publishBlindedBlock"
   description: |
     Instructs the beacon node to use the components of the `SignedBlindedBeaconBlock` to construct and publish a 

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -3,6 +3,7 @@ post:
     - Beacon
     - ValidatorRequiredApi
   summary: "Publish a signed block."
+  deprecated: true
   operationId: "publishBlock"
   description: |
     Instructs the beacon node to broadcast a newly signed beacon block to the beacon network,


### PR DESCRIPTION
v2 versions of [/eth/v1/beacon/blocks](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock) and [/eth/v1/beacon/blinded_blocks](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlindedBlock) were added during Deneb, therefore we can deprecate v1 versions in Electra and remove them in the F-fork.