### PR TITLE
Add Deneb and Electra light client spec

### DIFF
--- a/apis/beacon/light_client/bootstrap.yaml
+++ b/apis/beacon/light_client/bootstrap.yaml
@@ -32,6 +32,7 @@ get:
                 anyOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientBootstrap'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientBootstrap'
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Deneb.LightClientBootstrap'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientBootstrap'
         application/octet-stream:
           schema:

--- a/apis/beacon/light_client/bootstrap.yaml
+++ b/apis/beacon/light_client/bootstrap.yaml
@@ -32,6 +32,7 @@ get:
                 anyOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientBootstrap'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientBootstrap'
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientBootstrap'
         application/octet-stream:
           schema:
             description: "SSZ serialized `LightClientBootstrap` bytes. Use Accept header to choose this response type"

--- a/apis/beacon/light_client/finality_update.yaml
+++ b/apis/beacon/light_client/finality_update.yaml
@@ -27,6 +27,7 @@ get:
                 anyOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientFinalityUpdate'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientFinalityUpdate'
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Deneb.LightClientFinalityUpdate'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientFinalityUpdate'
         application/octet-stream:
           schema:

--- a/apis/beacon/light_client/finality_update.yaml
+++ b/apis/beacon/light_client/finality_update.yaml
@@ -27,6 +27,7 @@ get:
                 anyOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientFinalityUpdate'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientFinalityUpdate'
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientFinalityUpdate'
         application/octet-stream:
           schema:
             description: "SSZ serialized `LightClientFinalityUpdate` bytes. Use Accept header to choose this response type"

--- a/apis/beacon/light_client/optimistic_update.yaml
+++ b/apis/beacon/light_client/optimistic_update.yaml
@@ -27,6 +27,7 @@ get:
                 anyOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientOptimisticUpdate'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientOptimisticUpdate'
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Deneb.LightClientOptimisticUpdate'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientOptimisticUpdate'
         application/octet-stream:
           schema:

--- a/apis/beacon/light_client/optimistic_update.yaml
+++ b/apis/beacon/light_client/optimistic_update.yaml
@@ -27,6 +27,7 @@ get:
                 anyOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientOptimisticUpdate'
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientOptimisticUpdate'
+                  - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientOptimisticUpdate'
         application/octet-stream:
           schema:
             description: "SSZ serialized `LightClientOptimisticUpdate` bytes. Use Accept header to choose this response type"

--- a/apis/beacon/light_client/updates.yaml
+++ b/apis/beacon/light_client/updates.yaml
@@ -37,6 +37,7 @@ get:
                   anyOf:
                     - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientUpdate'
                     - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientUpdate'
+                    - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Deneb.LightClientUpdate'
                     - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientUpdate'
         application/octet-stream:
           schema:
@@ -61,7 +62,8 @@ get:
               | ------------------------------------------------------------------- | ------------------------------------- |
               | `GENESIS_FORK_VERSION`                                              | n/a                                   |
               | <nobr>`ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION`</nobr> | `altair.LightClientUpdate`            |
-              | <nobr>`CAPELLA_FORK_VERSION` through `DENEB_FORK_VERSION`</nobr>    | `capella.LightClientUpdate`           |
+              | <nobr>`CAPELLA_FORK_VERSION` </nobr>                                | `capella.LightClientUpdate`           |
+              | <nobr>`DENEB_FORK_VERSION` </nobr>                                  | `deneb.LightClientUpdate`             |
               | <nobr>`ELECTRA_FORK_VERSION` and later</nobr>                       | `electra.LightClientUpdate`           |
     "400":
       description: Malformed or missing request parameter

--- a/apis/beacon/light_client/updates.yaml
+++ b/apis/beacon/light_client/updates.yaml
@@ -37,6 +37,7 @@ get:
                   anyOf:
                     - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.LightClientUpdate'
                     - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Capella.LightClientUpdate'
+                    - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.LightClientUpdate'
         application/octet-stream:
           schema:
             description: |
@@ -60,7 +61,8 @@ get:
               | ------------------------------------------------------------------- | ------------------------------------- |
               | `GENESIS_FORK_VERSION`                                              | n/a                                   |
               | <nobr>`ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION`</nobr> | `altair.LightClientUpdate`            |
-              | <nobr>`CAPELLA_FORK_VERSION` and later</nobr>                       | `capella.LightClientUpdate`           |
+              | <nobr>`CAPELLA_FORK_VERSION` through `DENEB_FORK_VERSION`</nobr>    | `capella.LightClientUpdate`           |
+              | <nobr>`ELECTRA_FORK_VERSION` and later</nobr>                       | `electra.LightClientUpdate`           |
     "400":
       description: Malformed or missing request parameter
       content:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -387,6 +387,14 @@ components:
       $ref: './types/electra/attester_slashing.yaml#/Electra/AttesterSlashing'
     Electra.SignedAggregateAndProof:
       $ref: './types/electra/validator.yaml#/Electra/SignedAggregateAndProof'
+    Electra.LightClientBootstrap:
+      $ref: './types/electra/light_client.yaml#/Electra/LightClientBootstrap'
+    Electra.LightClientUpdate:
+      $ref: './types/electra/light_client.yaml#/Electra/LightClientUpdate'
+    Electra.LightClientFinalityUpdate:
+      $ref: './types/electra/light_client.yaml#/Electra/LightClientFinalityUpdate'
+    Electra.LightClientOptimisticUpdate:
+      $ref: './types/electra/light_client.yaml#/Electra/LightClientOptimisticUpdate'
     Node:
       $ref: './types/fork_choice.yaml#/Node'
     ExtraData:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -377,6 +377,14 @@ components:
       $ref: './types/deneb/block.yaml#/Deneb/BlindedBeaconBlock'
     Deneb.SignedBlindedBeaconBlock:
       $ref: './types/deneb/block.yaml#/Deneb/SignedBlindedBeaconBlock'
+    Deneb.LightClientBootstrap:
+      $ref: './types/deneb/light_client.yaml#/Deneb/LightClientBootstrap'
+    Deneb.LightClientUpdate:
+      $ref: './types/deneb/light_client.yaml#/Deneb/LightClientUpdate'
+    Deneb.LightClientFinalityUpdate:
+      $ref: './types/deneb/light_client.yaml#/Deneb/LightClientFinalityUpdate'
+    Deneb.LightClientOptimisticUpdate:
+      $ref: './types/deneb/light_client.yaml#/Deneb/LightClientOptimisticUpdate'
     Blob:
       $ref: './types/primitive.yaml#/Blob'
     Deneb.BlobSidecars:

--- a/types/deneb/light_client.yaml
+++ b/types/deneb/light_client.yaml
@@ -1,0 +1,64 @@
+Deneb:
+  LightClientHeader:
+    type: object
+    required: [beacon, execution, execution_branch]
+    properties:
+      beacon:
+        $ref: '../block.yaml#/BeaconBlockHeader'
+      execution:
+        $ref: './execution_payload.yaml#/Deneb/ExecutionPayloadHeader'
+      execution_branch:
+        $ref: '../capella/light_client.yaml#/Capella/ExecutionBranch'
+
+  LightClientBootstrap:
+    type: object
+    required: [header, current_sync_committee, current_sync_committee_branch]
+    properties:
+      header:
+        $ref: '#/Deneb/LightClientHeader'
+      current_sync_committee:
+        $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
+      current_sync_committee_branch:
+        $ref: '../altair/light_client.yaml#/Altair/CurrentSyncCommitteeBranch'
+  LightClientUpdate:
+    type: object
+    required: [attested_header, next_sync_committee, next_sync_committee_branch, finalized_header, finality_branch, sync_aggregate, signature_slot]
+    properties:
+      attested_header:
+        $ref: '#/Deneb/LightClientHeader'
+      next_sync_committee:
+        $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
+      next_sync_committee_branch:
+        $ref: '../altair/light_client.yaml#/Altair/NextSyncCommitteeBranch'
+      finalized_header:
+        $ref: '#/Deneb/LightClientHeader'
+      finality_branch:
+        $ref: '../altair/light_client.yaml#/Altair/FinalityBranch'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+      signature_slot:
+        $ref: '../primitive.yaml#/Uint64'
+  LightClientFinalityUpdate:
+    type: object
+    required: [attested_header, finalized_header, finality_branch, sync_aggregate, signature_slot]
+    properties:
+      attested_header:
+        $ref: '#/Deneb/LightClientHeader'
+      finalized_header:
+        $ref: '#/Deneb/LightClientHeader'
+      finality_branch:
+        $ref: '../altair/light_client.yaml#/Altair/FinalityBranch'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+      signature_slot:
+        $ref: '../primitive.yaml#/Uint64'
+  LightClientOptimisticUpdate:
+    type: object
+    required: [attested_header, sync_aggregate, signature_slot]
+    properties:
+      attested_header:
+        $ref: '#/Deneb/LightClientHeader'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+      signature_slot:
+        $ref: '../primitive.yaml#/Uint64'

--- a/types/electra/light_client.yaml
+++ b/types/electra/light_client.yaml
@@ -3,21 +3,21 @@ Electra:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/electra/light-client/sync-protocol.md#constants) roots"
     minItems: 7
     maxItems: 7
   CurrentSyncCommitteeBranch:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/electra/light-client/sync-protocol.md#constants) roots"
     minItems: 6
     maxItems: 6
   NextSyncCommitteeBranch:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/electra/light-client/sync-protocol.md#constants) roots"
     minItems: 6
     maxItems: 6
     

--- a/types/electra/light_client.yaml
+++ b/types/electra/light_client.yaml
@@ -26,7 +26,7 @@ Electra:
     required: [header, current_sync_committee, current_sync_committee_branch]
     properties:
       header:
-        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+        $ref: '../deneb/light_client.yaml#/Deneb/LightClientHeader'
       current_sync_committee:
         $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
       current_sync_committee_branch:
@@ -36,13 +36,13 @@ Electra:
     required: [attested_header, next_sync_committee, next_sync_committee_branch, finalized_header, finality_branch, sync_aggregate, signature_slot]
     properties:
       attested_header:
-        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+        $ref: '../deneb/light_client.yaml#/Deneb/LightClientHeader'
       next_sync_committee:
         $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
       next_sync_committee_branch:
         $ref: '#/Electra/NextSyncCommitteeBranch'
       finalized_header:
-        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+        $ref: '../deneb/light_client.yaml#/Deneb/LightClientHeader'
       finality_branch:
         $ref: '#/Electra/FinalityBranch'
       sync_aggregate:
@@ -54,9 +54,9 @@ Electra:
     required: [attested_header, finalized_header, finality_branch, sync_aggregate, signature_slot]
     properties:
       attested_header:
-        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+        $ref: '../deneb/light_client.yaml#/Deneb/LightClientHeader'
       finalized_header:
-        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+        $ref: '../deneb/light_client.yaml#/Deneb/LightClientHeader'
       finality_branch:
         $ref: '#/Electra/FinalityBranch'
       sync_aggregate:
@@ -68,7 +68,7 @@ Electra:
     required: [attested_header, sync_aggregate, signature_slot]
     properties:
       attested_header:
-        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+        $ref: '../deneb/light_client.yaml#/Deneb/LightClientHeader'
       sync_aggregate:
         $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
       signature_slot:

--- a/types/electra/light_client.yaml
+++ b/types/electra/light_client.yaml
@@ -1,0 +1,75 @@
+Electra:
+  FinalityBranch:
+    type: array
+    items:
+      $ref: '../primitive.yaml#/Root'
+      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/sync-protocol.md#constants) roots"
+    minItems: 7
+    maxItems: 7
+  CurrentSyncCommitteeBranch:
+    type: array
+    items:
+      $ref: '../primitive.yaml#/Root'
+      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/sync-protocol.md#constants) roots"
+    minItems: 6
+    maxItems: 6
+  NextSyncCommitteeBranch:
+    type: array
+    items:
+      $ref: '../primitive.yaml#/Root'
+      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/sync-protocol.md#constants) roots"
+    minItems: 6
+    maxItems: 6
+    
+  LightClientBootstrap:
+    type: object
+    required: [header, current_sync_committee, current_sync_committee_branch]
+    properties:
+      header:
+        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+      current_sync_committee:
+        $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
+      current_sync_committee_branch:
+        $ref: '#/Electra/CurrentSyncCommitteeBranch'
+  LightClientUpdate:
+    type: object
+    required: [attested_header, next_sync_committee, next_sync_committee_branch, finalized_header, finality_branch, sync_aggregate, signature_slot]
+    properties:
+      attested_header:
+        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+      next_sync_committee:
+        $ref: '../altair/sync_committee.yaml#/Altair/SyncCommittee'
+      next_sync_committee_branch:
+        $ref: '#/Electra/NextSyncCommitteeBranch'
+      finalized_header:
+        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+      finality_branch:
+        $ref: '#/Electra/FinalityBranch'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+      signature_slot:
+        $ref: '../primitive.yaml#/Uint64'
+  LightClientFinalityUpdate:
+    type: object
+    required: [attested_header, finalized_header, finality_branch, sync_aggregate, signature_slot]
+    properties:
+      attested_header:
+        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+      finalized_header:
+        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+      finality_branch:
+        $ref: '#/Electra/FinalityBranch'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+      signature_slot:
+        $ref: '../primitive.yaml#/Uint64'
+  LightClientOptimisticUpdate:
+    type: object
+    required: [attested_header, sync_aggregate, signature_slot]
+    properties:
+      attested_header:
+        $ref: '../capella/light_client.yaml#/Capella/LightClientHeader'
+      sync_aggregate:
+        $ref: '../altair/sync_aggregate.yaml#/Altair/SyncAggregate'
+      signature_slot:
+        $ref: '../primitive.yaml#/Uint64'


### PR DESCRIPTION
- Add LC related types for Deneb and Electra
- Update exist LC endpoints to include Deneb and Electra types

Note this PR is drafted according to the consensus spec in ethereum/consensus-specs#3875. As such, `Electra/LightClientHeader` is missing intentionally since it will be identical to `Deneb/LightClientHeader` after the PR is merged. 