### PR TITLE
clarify the consensus version headers

### DIFF
--- a/apis/beacon/blocks/attestations.v2.yaml
+++ b/apis/beacon/blocks/attestations.v2.yaml
@@ -15,7 +15,7 @@ get:
       headers:
         Eth-Consensus-Version:
           $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-          description: "The consensus version of the attestations"
+          description: "The active consensus version to which the attestations belong"
       content:
         application/json:
           schema:

--- a/apis/beacon/blocks/attestations.v2.yaml
+++ b/apis/beacon/blocks/attestations.v2.yaml
@@ -15,7 +15,7 @@ get:
       headers:
         Eth-Consensus-Version:
           $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
-          description: "The active consensus version to which the attestations belong"
+          description: "The active consensus version to which the attestations belong."
       content:
         application/json:
           schema:

--- a/apis/beacon/blocks/attestations.v2.yaml
+++ b/apis/beacon/blocks/attestations.v2.yaml
@@ -15,6 +15,7 @@ get:
       headers:
         Eth-Consensus-Version:
           $ref: '../../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+          description: "The consensus version of the attestations"
       content:
         application/json:
           schema:

--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -42,7 +42,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted."
+      description: "The consensus version of the block being submitted."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blinded_blocks.v2.yaml
+++ b/apis/beacon/blocks/blinded_blocks.v2.yaml
@@ -42,7 +42,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "The consensus version of the block being submitted."
+      description: "The active consensus version to which the block being submitted belongs."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -20,7 +20,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: false
       name: Eth-Consensus-Version
-      description: "The active consensus version to which the block being submitted belongs, if using SSZ encoding."
+      description: "The active consensus version to which the block being submitted belongs."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -20,7 +20,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: false
       name: Eth-Consensus-Version
-      description: "The consensus version of the block being submitted, if using SSZ encoding."
+      description: "The active consensus version to which the block being submitted belongs, if using SSZ encoding."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blinded_blocks.yaml
+++ b/apis/beacon/blocks/blinded_blocks.yaml
@@ -20,7 +20,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: false
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted, if using SSZ encoding."
+      description: "The consensus version of the block being submitted, if using SSZ encoding."
   requestBody:
     description: "The `SignedBlindedBeaconBlock` object composed of `BlindedBeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -41,7 +41,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "The consensus version of the block being submitted."
+      description: "The active consensus version to which the block being submitted belongs."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blocks.v2.yaml
+++ b/apis/beacon/blocks/blocks.v2.yaml
@@ -41,7 +41,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted."
+      description: "The consensus version of the block being submitted."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -19,7 +19,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: false
       name: Eth-Consensus-Version
-      description: "Version of the block being submitted, if using SSZ encoding."
+      description: "The consensus version of the block being submitted, if using SSZ encoding."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -19,7 +19,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: false
       name: Eth-Consensus-Version
-      description: "The consensus version of the block being submitted, if using SSZ encoding."
+      description: "The active consensus version to which the block being submitted belongs, if using SSZ encoding."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/blocks/blocks.yaml
+++ b/apis/beacon/blocks/blocks.yaml
@@ -19,7 +19,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: false
       name: Eth-Consensus-Version
-      description: "The active consensus version to which the block being submitted belongs, if using SSZ encoding."
+      description: "The active consensus version to which the block being submitted belongs."
   requestBody:
     description: "The `SignedBeaconBlock` object composed of `BeaconBlock` object (produced by beacon node) and validator signature."
     required: true

--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -67,7 +67,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the attestations being submitted."
+      description: "The consensus version of the attestations being submitted."
   tags:
     - Beacon
     - ValidatorRequiredApi

--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -67,7 +67,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "The consensus version of the attestations being submitted."
+      description: "The consensus version to which the attestations being submitted belong."
   tags:
     - Beacon
     - ValidatorRequiredApi

--- a/apis/beacon/pool/attester_slashings.v2.yaml
+++ b/apis/beacon/pool/attester_slashings.v2.yaml
@@ -42,7 +42,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "The consensus version of the attester slashing being submitted."
+      description: "The active consensus version to which the attester slashing being submitted belongs."
   tags:
     - Beacon
   requestBody:

--- a/apis/beacon/pool/attester_slashings.v2.yaml
+++ b/apis/beacon/pool/attester_slashings.v2.yaml
@@ -42,7 +42,7 @@ post:
         $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the attester slashing being submitted."
+      description: "The consensus version of the attester slashing being submitted."
   tags:
     - Beacon
   requestBody:

--- a/apis/validator/aggregate_and_proofs.v2.yaml
+++ b/apis/validator/aggregate_and_proofs.v2.yaml
@@ -11,7 +11,7 @@ post:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "Version of the aggregate and proofs being submitted."
+      description: "The consensus version of the aggregate and proofs being submitted."
   requestBody:
     required: true
     content:

--- a/apis/validator/aggregate_and_proofs.v2.yaml
+++ b/apis/validator/aggregate_and_proofs.v2.yaml
@@ -11,7 +11,7 @@ post:
         $ref: '../../beacon-node-oapi.yaml#/components/schemas/ConsensusVersion'
       required: true
       name: Eth-Consensus-Version
-      description: "The consensus version of the aggregate and proofs being submitted."
+      description: "The active consensus version to which the aggregate and proofs being submitted belong."
   requestBody:
     required: true
     content:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -425,7 +425,7 @@ components:
   headers:
     Eth-Consensus-Version:
       description: |
-        The consensus version of the data. Required in response so client can deserialize returned json or ssz data 
+        The active consensus version to which the data belongs. Required in response so client can deserialize returned json or ssz data 
         more effectively.
       required: true
       schema:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -424,7 +424,9 @@ components:
 
   headers:
     Eth-Consensus-Version:
-      description: Required in response so client can deserialize returned json or ssz data more effectively.
+      description: |
+        The consensus version of the data. Required in response so client can deserialize returned json or ssz data 
+        more effectively.
       required: true
       schema:
         $ref: '#/components/schemas/ConsensusVersion'


### PR DESCRIPTION
The `Eth-Consensus-Version` header usage is ambiguous and could be misinterpreted. It shouldn't be tied up to the data schema but rather to the consensus version/fork the data belongs to.
For example since EIP7549, there are 2 possible attestations schemas only: `Attestation` (phase0) and `Electra.Attestation` (electra) but that doesn't mean that the `Eth-Consensus-Version` can only be `phase0` or `electra` but rather any value according to when the attestation is submitted or retrieved (Example: a `deneb` attestation will have an `Attestation` schema and `deneb` as value in the `Eth-Consensus-Version`).
When it come to the block related APIs, the problem is less concerning because there is schema per fork and hence any value could be used. 