### PR TITLE
Make nodes required in debug fork choice endpoint

### DIFF
--- a/apis/debug/fork_choice.yaml
+++ b/apis/debug/fork_choice.yaml
@@ -13,7 +13,7 @@ get:
             title: GetForkChoiceResponse
             type: object
             description: "Debugging context of fork choice"
-            required: [justified_checkpoint, finalized_checkpoint]
+            required: [justified_checkpoint, finalized_checkpoint, fork_choice_nodes]
             properties:
               justified_checkpoint:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Checkpoint'


### PR DESCRIPTION
I don't think it makes sense for the response to omit `fork_choice_nodes`, it should be a required property.

Ref https://github.com/ethereum/beacon-APIs/pull/232