### PR TITLE
Update blinded block to contain execution requests instead of root

### DIFF
--- a/types/electra/block.yaml
+++ b/types/electra/block.yaml
@@ -80,12 +80,12 @@ Electra:
     allOf:
       - $ref: "#/Electra/BeaconBlockBodyCommon"
       - type: object
-        required: [execution_payload_header, execution_requests_root]
+        required: [execution_payload_header, execution_requests]
         properties:
           execution_payload_header:
             $ref: "../deneb/execution_payload.yaml#/Deneb/ExecutionPayloadHeader"
-          execution_requests_root:
-            $ref: "../primitive.yaml#/Root"
+          execution_requests:
+            $ref: "./execution_requests.yaml#/Electra/ExecutionRequests"
 
   BlindedBeaconBlock:
     description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/phase0/beacon-chain.md#beaconblock) object from the CL Electra spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."


### PR DESCRIPTION
Latest changes from https://github.com/ethereum/builder-specs/pull/101 pass `execution_requests` instead of just the root in the blinded block, see PR for rationale.