### PR TITLE
Rename `PendingBalanceDeposit` to `PendingDeposit`

### DIFF
--- a/types/electra/deposit.yaml
+++ b/types/electra/deposit.yaml
@@ -37,4 +37,4 @@ Electra:
         $ref: "../primitive.yaml#/Signature"
       slot:
         $ref: "../primitive.yaml#/Uint64"
-        description: "The slot at which the deposit request was processed"
+        description: "The slot at which the deposit request was processed."

--- a/types/electra/deposit.yaml
+++ b/types/electra/deposit.yaml
@@ -19,9 +19,9 @@ Electra:
         $ref: "../primitive.yaml#/Uint64"
         description: "The index of the deposit request."
 
-  PendingBalanceDeposit:
+  PendingDeposit:
     type: object
-    description: "The [`PendingBalanceDeposit`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#pendingbalancedeposit) object from the CL Electra spec."
+    description: "The [`PendingDeposit`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#pendingdeposit) object from the CL Electra spec."
     required: [index, amount]
     properties:
       index:

--- a/types/electra/deposit.yaml
+++ b/types/electra/deposit.yaml
@@ -22,11 +22,19 @@ Electra:
   PendingDeposit:
     type: object
     description: "The [`PendingDeposit`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#pendingdeposit) object from the CL Electra spec."
-    required: [index, amount]
+    required: [pubkey, withdrawal_credentials, amount, signature, slot]
     properties:
-      index:
-        $ref: "../primitive.yaml#/Uint64"
-        description: "Index of validator in validator registry."
+      pubkey:
+        $ref: "../primitive.yaml#/Pubkey"
+        description: "BLS public key of validator."
+      withdrawal_credentials:
+        $ref: "../primitive.yaml#/Root"
+        description: "The withdrawal credentials."
       amount:
         $ref: "../primitive.yaml#/Gwei"
         description: "The value to be deposited (gwei)."
+      signature:
+        $ref: "../primitive.yaml#/Signature"
+      slot:
+        $ref: "../primitive.yaml#/Uint64"
+        description: "The slot at which the deposit request was processed"

--- a/types/electra/state.yaml
+++ b/types/electra/state.yaml
@@ -2,7 +2,7 @@ Electra:
   BeaconState:
     type: object
     description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#beaconstate) object from the CL Electra spec."
-    required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee, latest_execution_payload_header, next_withdrawal_index, next_withdrawal_validator_index, historical_summaries, deposit_requests_start_index, deposit_balance_to_consume, exit_balance_to_consume, earliest_exit_epoch, consolidation_balance_to_consume, earliest_consolidation_epoch, pending_balance_deposits, pending_partial_withdrawals, pending_consolidations]
+    required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee, latest_execution_payload_header, next_withdrawal_index, next_withdrawal_validator_index, historical_summaries, deposit_requests_start_index, deposit_balance_to_consume, exit_balance_to_consume, earliest_exit_epoch, consolidation_balance_to_consume, earliest_consolidation_epoch, pending_deposits, pending_partial_withdrawals, pending_consolidations]
     properties:
       genesis_time:
         $ref: "../primitive.yaml#/Uint64"
@@ -104,10 +104,10 @@ Electra:
         $ref: "../primitive.yaml#/Gwei"
       earliest_consolidation_epoch:
         $ref: "../primitive.yaml#/Uint64"
-      pending_balance_deposits:
+      pending_deposits:
         type: array
         items:
-          $ref: "./deposit.yaml#/Electra/PendingBalanceDeposit"
+          $ref: "./deposit.yaml#/Electra/PendingDeposit"
         maxItems: 134217728
       pending_partial_withdrawals:
         type: array


### PR DESCRIPTION
The latest spec renames `PendingBalanceDeposit` to `PendingDeposit`. Same with the field `pending_balance_deposits` to `pending_deposits` in beacon state