### PR TITLE
Update primitive.yaml: Add Bytes primitive

### DIFF
--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -95,7 +95,7 @@ Bytes:
   format: hex
   description: "An arbitrary-length sequence of bytes"
   example: "0x02a94f5374fce5edbc8e2a8697c15331677e6ebf0b85103a5617937691dfeeb89b86a80d5dc9e3c9d3a1a0e7ce311e26e0bb732eabaa47ffa288f0d54de28209a62a7d29d098daeed734da114470da559bd4b4c7259e1f7952555241dcbc90cf194a2ef676fc6005f3672fada2a3645edb297a7553"
-  pattern: "^0x[a-fA-F0-9]{2,}$"
+  pattern: "^0x([0-9a-fA-F][0-9a-fA-F])+$"
 
 Uint8:
   type: string

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -90,6 +90,13 @@ Bitvector:
   example: "0x01"
   pattern: "^0x[a-fA-F0-9]{2,}$"
 
+Bytes:
+  type: string
+  format: hex
+  description: "An arbitrary-length sequence of bytes"
+  example: "0x02a94f5374fce5edbc8e2a8697c15331677e6ebf0b85103a5617937691dfeeb89b86a80d5dc9e3c9d3a1a0e7ce311e26e0bb732eabaa47ffa288f0d54de28209a62a7d29d098daeed734da114470da559bd4b4c7259e1f7952555241dcbc90cf194a2ef676fc6005f3672fada2a3645edb297a7553"
+  pattern: "^0x[a-fA-F0-9]{2,}$"
+
 Uint8:
   type: string
   description: "Unsigned 8 bit integer, max value 255"


### PR DESCRIPTION
This came up in https://github.com/ethereum/builder-specs/pull/107#discussion_r1872481158 (/cc @lucassaldanha).  I agree with Lucas that Bitvector is probably wrong, and that currently we don't have a good primitive to express this.

I'm also not terribly familiar with the beacon API types though, so am open to other options, both in naming and format.

Some points of discussion:

- Alternative names: `ByteVector`?
- I'm honestly not sure if the regex should be `{2,}` (which I started with) or `{0,}` since before the latest changes to EIP-7865 the empty requests were encoded as `"0x"` which `{2,}` doesn't allow.
- I could instead refactor the build spec since really the requests _are_ bounded to `sizeof(largest request type) * max_request_count_per_block + 1` but that seemed to get really deep in the weeds for a field thats meany to be opaque for most purposes.