### PR TITLE
chore(ci): update actions/upload|download-artifact from v3 to v4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
           file: "beacon-node-oapi.json"
           target: "deploy/releases/${{ matrix.release }}/beacon-node-oapi.json"
       - name: Save releases (artifact)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: releases
           retention-days: 7
@@ -48,7 +48,7 @@ jobs:
           cp index.html ./deploy
           cp validator-flow.md ./deploy
       - name: Restore releases
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: releases
           path: deploy/releases


### PR DESCRIPTION
Due to deprecation notice: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ 