### PR TITLE
Add `custody_group_count` to metadata in `node/identity` response

### DIFF
--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -36,6 +36,9 @@ MetaData:
       description: "Bitvector representing the node's sync committee subnet subscriptions. This metadata is not present in phase0, but will be present in Altair."
       $ref: "./primitive.yaml#/Bitvector"
       example: "0x0f"
+    custody_group_count:
+      description: "Uint64 representing the node's custody group count. The metadata is present from the Fulu fork."
+      $ref: "./primitive.yaml#/Uint64"
 
 Peer:
   type: object


### PR DESCRIPTION
Add `custody_group_count` to metadata.

This field is part of `MetaDataV3` used by PeerDAS and will be available from the Fulu fork.

https://github.com/ethereum/consensus-specs/blob/e79ef816aef05e34eff0b53311cf50c13fb67fc9/specs/fulu/p2p-interface.md?plain=1#L159