### PR TITLE
Update electra spec references to latest release

### DIFF
--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -27,7 +27,7 @@ info:
 
     Note that it is possible for a field to be added to an endpoint's data or metadata without an increase in the version number.
 
-  version: "Dev - Ethereum Proof-of-Stake Consensus Specification v1.4.0"
+  version: "Dev - Ethereum Proof-of-Stake Consensus Specification v1.5.0"
   contact:
     name: Ethereum Github
     url: https://github.com/ethereum/beacon-apis/issues

--- a/types/electra/attestation.yaml
+++ b/types/electra/attestation.yaml
@@ -1,7 +1,7 @@
 Electra:
   IndexedAttestation:
     type: object
-    description: "The [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#indexedattestation) object from the CL spec."
+    description: "The [`IndexedAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#indexedattestation) object from the CL spec."
     required: [attesting_indices, data, signature]
     properties:
       attesting_indices:
@@ -18,7 +18,7 @@ Electra:
 
   SingleAttestation:
     type: object
-    description: "The [`SingleAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/electra/beacon-chain.md#singleattestation) object from the CL spec."
+    description: "The [`SingleAttestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#singleattestation) object from the CL spec."
     required: [committee_index, attester_index, data, signature]
     properties:
       committee_index:
@@ -35,7 +35,7 @@ Electra:
 
   Attestation:
     type: object
-    description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#attestation) object from the CL spec."
+    description: "The [`Attestation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#attestation) object from the CL spec."
     required: [aggregation_bits, data, signature, committee_bits]
     properties:
       aggregation_bits:

--- a/types/electra/attester_slashing.yaml
+++ b/types/electra/attester_slashing.yaml
@@ -1,7 +1,7 @@
 Electra:
   AttesterSlashing:
     type: object
-    description: "The [`AttesterSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#attesterslashing) object from the CL spec."
+    description: "The [`AttesterSlashing`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#attesterslashing) object from the CL spec."
     required: [attestation_1, attestation_2]
     properties:
       attestation_1:

--- a/types/electra/block.yaml
+++ b/types/electra/block.yaml
@@ -2,7 +2,7 @@ Electra:
   BeaconBlockBodyCommon:
     # An abstract object to collect the common fields between the BeaconBlockBody and the BlindedBeaconBlockBody objects
     type: object
-    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#beaconblockbody) object from the CL Electra spec."
+    description: "The [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#beaconblockbody) object from the CL Electra spec."
     required: [randao_reveal, eth1_data, graffiti, proposer_slashings, attester_slashings, attestations, deposits, voluntary_exits, sync_aggregate, bls_to_execution_changes, blob_kzg_commitments]
     properties:
       randao_reveal:
@@ -56,7 +56,7 @@ Electra:
             $ref: "./execution_requests.yaml#/Electra/ExecutionRequests"
 
   BeaconBlock:
-    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/phase0/beacon-chain.md#beaconblock) object from the CL Electra spec."
+    description: "The [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/beacon-chain.md#beaconblock) object from the CL Electra spec."
     allOf:
       - $ref: "../altair/block.yaml#/Altair/BeaconBlockCommon"
       - type: object
@@ -67,7 +67,7 @@ Electra:
 
   SignedBeaconBlock:
     type: object
-    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Electra spec."
+    description: "The [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Electra spec."
     required: [message, signature]
     properties:
       message:
@@ -76,7 +76,7 @@ Electra:
         $ref: "../primitive.yaml#/Signature"
 
   BlindedBeaconBlockBody:
-    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#beaconblockbody) object from the CL Electra spec, which contains a transactions root rather than a full transactions list."
+    description: "A variant of the [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#beaconblockbody) object from the CL Electra spec, which contains a transactions root rather than a full transactions list."
     allOf:
       - $ref: "#/Electra/BeaconBlockBodyCommon"
       - type: object
@@ -88,7 +88,7 @@ Electra:
             $ref: "./execution_requests.yaml#/Electra/ExecutionRequests"
 
   BlindedBeaconBlock:
-    description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/phase0/beacon-chain.md#beaconblock) object from the CL Electra spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
+    description: "A variant of the [`BeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/beacon-chain.md#beaconblock) object from the CL Electra spec, which contains a `BlindedBeaconBlockBody` rather than a `BeaconBlockBody`."
     allOf:
       - $ref: "../altair/block.yaml#/Altair/BeaconBlockCommon"
       - type: object
@@ -99,7 +99,7 @@ Electra:
 
   SignedBlindedBeaconBlock:
     type: object
-    description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Electra spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
+    description: "A variant of the [`SignedBeaconBlock`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/beacon-chain.md#signedbeaconblock) object envelope from the CL Electra spec, which contains a `BlindedBeaconBlock` rather than a `BeaconBlock`."
     required: [message, signature]
     properties:
       message:

--- a/types/electra/consolidation.yaml
+++ b/types/electra/consolidation.yaml
@@ -1,7 +1,7 @@
 Electra:
   ConsolidationRequest:
     type: object
-    description: "The [`ConsolidationRequest`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#consolidationrequest) object from the CL Electra spec."
+    description: "The [`ConsolidationRequest`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#consolidationrequest) object from the CL Electra spec."
     required: [source_address, source_pubkey, target_pubkey]
     properties:
       source_address:
@@ -16,7 +16,7 @@ Electra:
 
   PendingConsolidation:
     type: object
-    description: "The [`PendingConsolidation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#pendingconsolidation) object from the CL Electra spec."
+    description: "The [`PendingConsolidation`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#pendingconsolidation) object from the CL Electra spec."
     required: [source_index, target_index]
     properties:
       source_index:

--- a/types/electra/deposit.yaml
+++ b/types/electra/deposit.yaml
@@ -1,7 +1,7 @@
 Electra:
   DepositRequest:
     type: object
-    description: "The [`DepositRequest`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#depositrequest) object from the CL Electra spec."
+    description: "The [`DepositRequest`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#depositrequest) object from the CL Electra spec."
     required: [pubkey, withdrawal_credentials, amount, signature, index]
     properties:
       pubkey:
@@ -21,7 +21,7 @@ Electra:
 
   PendingDeposit:
     type: object
-    description: "The [`PendingDeposit`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#pendingdeposit) object from the CL Electra spec."
+    description: "The [`PendingDeposit`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#pendingdeposit) object from the CL Electra spec."
     required: [pubkey, withdrawal_credentials, amount, signature, slot]
     properties:
       pubkey:

--- a/types/electra/execution_requests.yaml
+++ b/types/electra/execution_requests.yaml
@@ -1,7 +1,7 @@
 Electra:  
   ExecutionRequests:
     type: object
-    description: "The [`ExecutionRequests`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.6/specs/electra/beacon-chain.md#executionrequests) object from the CL Electra spec."
+    description: "The [`ExecutionRequests`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#executionrequests) object from the CL Electra spec."
     required: [deposits, withdrawals, consolidations]
     properties:
       deposits:

--- a/types/electra/light_client.yaml
+++ b/types/electra/light_client.yaml
@@ -3,21 +3,21 @@ Electra:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/electra/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/light-client/sync-protocol.md#constants) roots"
     minItems: 7
     maxItems: 7
   CurrentSyncCommitteeBranch:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/electra/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/light-client/sync-protocol.md#constants) roots"
     minItems: 6
     maxItems: 6
   NextSyncCommitteeBranch:
     type: array
     items:
       $ref: '../primitive.yaml#/Root'
-      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/electra/light-client/sync-protocol.md#constants) roots"
+      description: "Merkle proof consisting of [`log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA])`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/light-client/sync-protocol.md#constants) roots"
     minItems: 6
     maxItems: 6
     

--- a/types/electra/state.yaml
+++ b/types/electra/state.yaml
@@ -1,7 +1,7 @@
 Electra:
   BeaconState:
     type: object
-    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#beaconstate) object from the CL Electra spec."
+    description: "The [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#beaconstate) object from the CL Electra spec."
     required: [genesis_time, genesis_validators_root, slot, fork, latest_block_header, block_roots, state_roots, historical_roots, eth1_data, eth1_data_votes, eth1_deposit_index, validators, balances, randao_mixes, slashings, previous_epoch_participation, current_epoch_participation, justification_bits, previous_justified_checkpoint, current_justified_checkpoint, finalized_checkpoint, inactivity_scores, current_sync_committee, next_sync_committee, latest_execution_payload_header, next_withdrawal_index, next_withdrawal_validator_index, historical_summaries, deposit_requests_start_index, deposit_balance_to_consume, exit_balance_to_consume, earliest_exit_epoch, consolidation_balance_to_consume, earliest_consolidation_epoch, pending_deposits, pending_partial_withdrawals, pending_consolidations]
     properties:
       genesis_time:

--- a/types/electra/validator.yaml
+++ b/types/electra/validator.yaml
@@ -10,7 +10,7 @@ Electra:
 
   Aggregate:
     type: object
-    description: "The [`AggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/validator.md#aggregateandproof) without selection_proof"
+    description: "The [`AggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/validator.md#aggregateandproof) without selection_proof"
     required: [aggregator_index, aggregate]
     properties:
       aggregator_index:
@@ -20,7 +20,7 @@ Electra:
 
   SignedAggregateAndProof:
     type: object
-    description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/validator.md#signedaggregateandproof) object"
+    description: "The [`SignedAggregateAndProof`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/validator.md#signedaggregateandproof) object"
     required: [message, signature]
     properties:
       message:

--- a/types/electra/withdrawal.yaml
+++ b/types/electra/withdrawal.yaml
@@ -1,7 +1,7 @@
 Electra:
   WithdrawalRequest:
     type: object
-    description: "The [`WithdrawalRequest`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#withdrawalrequest) object from the CL Electra spec."
+    description: "The [`WithdrawalRequest`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#withdrawalrequest) object from the CL Electra spec."
     required: [source_address, validator_pubkey, amount]
     properties:
       source_address:
@@ -16,7 +16,7 @@ Electra:
 
   PendingPartialWithdrawal:
     type: object
-    description: "The [`PendingPartialWithdrawal`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#pendingpartialwithdrawal) object from the CL Electra spec."
+    description: "The [`PendingPartialWithdrawal`](https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/beacon-chain.md#pendingpartialwithdrawal) object from the CL Electra spec."
     required: [validator_index, amount, withdrawable_epoch]
     properties:
       validator_index:


### PR DESCRIPTION
Closes https://github.com/ethereum/beacon-APIs/issues/454, I think we are fine with updating to latest release for now, can update references to stable release once it's out but it shouldn't be a blocker for cutting a new api release.