### PR TITLE
Remove incorrect usage of additionalProperties

### DIFF
--- a/types/bellatrix/execution_payload.yaml
+++ b/types/bellatrix/execution_payload.yaml
@@ -47,7 +47,6 @@ Bellatrix:
     allOf:
       - $ref: '#/Bellatrix/ExecutionPayloadCommon'
       - type: object
-        additionalProperties: false
         required: [transactions_root]
         properties:
           transactions_root:

--- a/types/capella/execution_payload.yaml
+++ b/types/capella/execution_payload.yaml
@@ -49,7 +49,6 @@ Capella:
     allOf:
       - $ref: '#/Capella/ExecutionPayloadCommon'
       - type: object
-        additionalProperties: false
         required: [transactions_root, withdrawals_root]
         properties:
           transactions_root:


### PR DESCRIPTION
The usage of `additionalProperties: false` here is incorrect as each sub schema is evaluated independently, so what ends up happening is that when the second schema is evaluated which only has `transactions_root` as property, it will complain that there are additional properties if we pass a `ExecutionPayloadHeader` value since it has more properties like `parent_hash`.

This is the error when running spec tests in Lodestar
```
/body/message/body/execution_payload_header - must NOT have additional properties
```
And the more detailed error
```js
{
  instancePath: "/body/message/body/execution_payload_header",
  schemaPath: "#/properties/body/anyOf/0/properties/message/allOf/1/properties/body/allOf/1/properties/execution_payload_header/allOf/1/additionalProperties",
  keyword: "additionalProperties",
  params: {
    additionalProperty: "parent_hash",
  },
  message: "must NOT have additional properties",
}
```

It also seems like we only use  `additionalProperties: false` in the bellatrix types.

eg. capella types don't use it
https://github.com/ethereum/beacon-APIs/blob/5815ac5b3a4bfcac2faa2c09200b57cb29df72bc/types/capella/execution_payload.yaml#L49-L53

