### PR TITLE
Apply oneOf to submit attestations api as intended

### DIFF
--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -33,7 +33,7 @@ get:
                 enum: [phase0, altair, bellatrix, capella, deneb, electra]
                 example: "phase0"
               data:
-                oneOf:
+                anyOf:
                   - type: array
                     items:
                       $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Phase0.Attestation'
@@ -78,7 +78,7 @@ post:
     content:
       application/json:
         schema:
-          anyOf:
+          oneOf:
             - type: array
               items:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Phase0.Attestation'


### PR DESCRIPTION
The intend of https://github.com/ethereum/beacon-APIs/pull/492 was to apply `oneOf` to `submitPoolAttestationsV2` but it was applied to `getPoolAttestationsV2` which causes issues as outlined here https://github.com/ethereum/beacon-APIs/pull/492#discussion_r1937508072.

Alternative would just be to use `anyOf` everywhere
