### PR TITLE
Run CI build step if commit is pushed to release branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "release-*"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Noticed CI build step was not triggered when the release workflow opened the PR here https://github.com/ethereum/beacon-APIs/pull/506 but we need that job to succeed to pass required merge checks.

This PR should solve this by running the job when the release commit is pushed to the branch.