### PR TITLE
Add SSZ support to register validator api

### DIFF
--- a/apis/validator/register_validator.yaml
+++ b/apis/validator/register_validator.yaml
@@ -20,10 +20,15 @@ post:
           type: array
           items:
             $ref: '../../beacon-node-oapi.yaml#/components/schemas/SignedValidatorRegistration'
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `List[SignedValidatorRegistrationV1, VALIDATOR_REGISTRY_LIMIT]` bytes. Use content type header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: Registration information has been received.
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "415":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'


### PR DESCRIPTION
To accommodate https://github.com/ethereum/builder-specs/pull/110, since the endpoint is mostly just a pass through of the request from the validator client to the builder, this allows to skip an extra serialization step and overall should make it more seamless if SSZ is used.