### PR TITLE
require that Electra produceAttestationData AttestationData have 0 committee_index

### DIFF
--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -4,6 +4,7 @@ get:
     - Validator
   operationId: "produceAttestationData"
   summary: "Produce an attestation data"
+  deprecated: true
   description: |
     Requests that the beacon node produce an AttestationData. For `slot`s in
     Electra and later, this AttestationData must have a `committee_index` of 0.

--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -5,7 +5,8 @@ get:
   operationId: "produceAttestationData"
   summary: "Produce an attestation data"
   description: |
-    Requests that the beacon node produce an AttestationData.
+    Requests that the beacon node produce an AttestationData. For `slot`s in
+    Electra and later, this AttestationData must have a `committee_index` of 0.
 
     A 503 error must be returned if the block identified by the response
     `beacon_block_root` is optimistic (i.e. the attestation attests to a block

--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -4,7 +4,6 @@ get:
     - Validator
   operationId: "produceAttestationData"
   summary: "Produce an attestation data"
-  deprecated: true
   description: |
     Requests that the beacon node produce an AttestationData. For `slot`s in
     Electra and later, this AttestationData must have a `committee_index` of 0.


### PR DESCRIPTION
Currently, it's ambiguous whether a VC which specified a non-zero `committee_index` in Electra would get an `AttestationData` in return. This is a potential source of VC/BN Electra [interoperability issues](https://github.com/ethpandaops/ethereum-package?tab=readme-ov-file#beacon-node--validator-client-compatibility), as each VC or BN might rely on the other element of its pair for that client to enforce the 0-constraint. Ensure that the BN, at least, does so.