### PR TITLE
Update AttestationData example to use 0 as index to be valid post-electra

### DIFF
--- a/types/phase0/attestation_data.yaml
+++ b/types/phase0/attestation_data.yaml
@@ -8,6 +8,7 @@ Phase0:
         $ref: "../primitive.yaml#/Uint64"
       index:
         $ref: "../primitive.yaml#/Uint64"
+        example: "0"
       beacon_block_root:
         $ref: '../primitive.yaml#/Root'
         description: "LMD GHOST vote."


### PR DESCRIPTION
As noted by @tersec on [discord](https://discord.com/channels/595666850260713488/710831784991916072/1351216847642427522), the example(s) shown in [getAggregatedAttestationV2](https://ethereum.github.io/beacon-APIs/?urls.primaryName=v3.0.0#/Validator/getAggregatedAttestationV2) and other attestation related apis are not valid as post-electra the `index` in `AttestationData` must always be 0.

Eg. for `getAggregatedAttestationV2` it would show this example now
```json
{
  "version": "electra",
  "data": {
    "aggregation_bits": "0x01",
    "data": {
      "slot": "1",
      "index": "0",
      "beacon_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
      "source": {
        "epoch": "1",
        "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
      },
      "target": {
        "epoch": "1",
        "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
      }
    },
    "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
    "committee_bits": "0x0000000000000001"
  }
}
```