### PR TITLE
Clarify handling of empty arrays for ids/statuses in validators api

### DIFF
--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -115,12 +115,19 @@ post:
             ids:
               type: array
               uniqueItems: true
+              description: |
+                  An array of values, with each value either a hex encoded public key (any bytes48 with 0x prefix) or a validator index.
+
+                  If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then all validators will be returned.
               items:
-                description: "Either hex encoded public key (any bytes48 with 0x prefix) or validator index"
                 type: string
             statuses:
               type: array
               uniqueItems: true
+              description: |
+                  [Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)
+
+                  If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then validators with all statuses will be returned.
               items:
                 oneOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus'

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -116,18 +116,18 @@ post:
               type: array
               uniqueItems: true
               description: |
-                  An array of values, with each value either a hex encoded public key (any bytes48 with 0x prefix) or a validator index.
+                An array of values, with each value either a hex encoded public key (any bytes48 with 0x prefix) or a validator index.
 
-                  If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then all validators will be returned.
+                If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then all validators will be returned.
               items:
                 type: string
             statuses:
               type: array
               uniqueItems: true
               description: |
-                  [Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)
+                [Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)
 
-                  If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then validators with all statuses will be returned.
+                If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then validators with all statuses will be returned.
               items:
                 oneOf:
                   - $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorStatus'

--- a/apis/beacon/states/validators.yaml
+++ b/apis/beacon/states/validators.yaml
@@ -125,7 +125,7 @@ post:
               type: array
               uniqueItems: true
               description: |
-                [Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)
+                An array of validator statuses to filter on.
 
                 If the supplied list is empty (i.e. the value is `[]`) or the property is omitted then validators with all statuses will be returned.
               items:


### PR DESCRIPTION
Similar https://github.com/ethereum/beacon-APIs/pull/453, clarifies handling of empty arrays, ie. if the value is `[]` then no filtering should be applied and all validators should be returned. Since this [caused interop issues](https://discord.com/channels/595666850260713488/892088344438255616/1348727918951665815) just recently, I think it's worth clarifying this behavior on the spec. 
cc @james-prysm @pawanjay176 are you fine with the described behavior?