### PR TITLE
Add the ability to easily query liveness of all validators

### DIFF
--- a/apis/validator/liveness.yaml
+++ b/apis/validator/liveness.yaml
@@ -20,7 +20,10 @@ post:
       schema:
         $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"
   requestBody:
-    description: "An array of the validator indices for which to detect liveness."
+    description: |
+      An array of the validator indices for which to detect liveness.
+
+      If the supplied list is empty (i.e. the body is `[]`) or no body is supplied then liveness will be returned for all validators.
     required: true
     content:
       application/json:


### PR DESCRIPTION
The goal is to make monitoring tools that watch the entire network more efficient by not having to send the full list of validators indexes.

This is aligned with the current semantics of the `/eth/v1/beacon/states/{state_id}/validator_balances` call, which treats empty lists as full validator set.