### PR TITLE
Add endpoint to retrieve exit and withdrawable epochs for a validator

### DIFF
--- a/apis/validator/withdrawable_epochs.yaml
+++ b/apis/validator/withdrawable_epochs.yaml
@@ -1,0 +1,29 @@
+get:
+  operationId: getWithdrawableEpochs
+  summary: Get exit and withdrawable epochs of a validator
+  description: Returns the exit and withdrawable epochs for a given validator ID.
+  tags:
+    - Beacon
+  parameters:
+    - name: validator_id
+      in: path
+      required: true
+      description: ID of the validator to query
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Successfully retrieved withdrawable info
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              exit_epoch:
+                type: string
+                description: Epoch when validator exits
+              withdrawable_epoch:
+                type: string
+                description: Epoch when validator becomes withdrawable
+    '404':
+      description: Validator not found

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -138,6 +138,8 @@ paths:
     $ref: "./apis/beacon/light_client/optimistic_update.yaml"
   /eth/v1/beacon/pool/attestations:
     $ref: "./apis/beacon/pool/attestations.yaml"
+  /eth/v1/beacon/validators/{validator_id}/withdrawable_epochs:
+  $ref: "./apis/beacon/validators/withdrawable_epochs.yaml"
   /eth/v2/beacon/pool/attestations:
     $ref: "./apis/beacon/pool/attestations.v2.yaml"
   /eth/v1/beacon/pool/attester_slashings:


### PR DESCRIPTION
This PR adds a new lightweight API endpoint to retrieve a validator’s exit_epoch and withdrawable_epoch, addressing the enhancement requested in [Issue #308](https://github.com/ethereum/beacon-APIs/issues/308).

Instead of fetching the full validator set via /eth/v1/beacon/states/{state_id}/validators, this new endpoint allows querying only a specific validator by ID, simplifying application development and reducing unnecessary data transfer.