### PR TITLE
Add SSZ support to attestation apis

### DIFF
--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -85,6 +85,9 @@ post:
             - type: array
               items:
                 $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Phase0.Attestation'
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `List[Attestation, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` or `List[SingleAttestation, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` bytes. Use content type header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: Attestations are stored in pool and broadcast on the appropriate subnet
@@ -94,5 +97,7 @@ post:
         application/json:
           schema:
             $ref: "../../../beacon-node-oapi.yaml#/components/schemas/IndexedErrorMessage"
+    "415":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/aggregate_and_proofs.v2.yaml
+++ b/apis/validator/aggregate_and_proofs.v2.yaml
@@ -24,10 +24,15 @@ post:
             - type: array
               items:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Phase0.SignedAggregateAndProof'
+      application/octet-stream:
+        schema:
+          description: "SSZ serialized `List[SignedAggregateAndProof, MAX_COMMITTEES_PER_SLOT * TARGET_AGGREGATORS_PER_COMMITTEE]` bytes. Use content type header to indicate that SSZ data is contained in the request body."
   responses:
     "200":
       description: "Successful response"
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "415":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/aggregate_attestation.v2.yaml
+++ b/apis/validator/aggregate_attestation.v2.yaml
@@ -51,9 +51,14 @@ get:
                 anyOf:
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Electra.Attestation'
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Phase0.Attestation'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `Attestation` bytes. Use Accept header to choose this response type"
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "404":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/NotFound'
+    "406":
+      $ref: "../../beacon-node-oapi.yaml#/components/responses/NotAcceptable"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -36,8 +36,13 @@ get:
             properties:
               data:
                 $ref: '../../beacon-node-oapi.yaml#/components/schemas/Phase0.AttestationData'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `AttestationData` bytes. Use Accept header to choose this response type"
     "400":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
+    "406":
+      $ref: '../../beacon-node-oapi.yaml#/components/responses/NotAcceptable'
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
     "503":


### PR DESCRIPTION
Add SSZ support to attestation apis used by the validator client which are part of the hot path.

There are 2 notes which are pretty repetitive
- "Use content type header to indicate that SSZ data is contained in the request body."
- "Use Accept header to choose this response type"

We should consider removing them since there is a [more general note](https://github.com/ethereum/beacon-APIs/blob/6d3fd4d833b37ab5e20308587df8674ffcf67eb6/beacon-node-oapi.yaml#L8-L17) for this already but I added them for now to be consistent with existing apis. Can do a follow-up PR to remove them across all apis, or do a PR before merging this, depending on others preferences.