### PR TITLE
Add blob schedule example to config/spec api

### DIFF
--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -10,6 +10,7 @@ get:
     Values are returned with following format:
       - any value starting with 0x in the spec is returned as a hex string
       - numeric values are returned as a quoted integer
+      - array values are returned as a JSON array
   tags:
     - Config
     - ValidatorRequiredApi

--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -37,6 +37,6 @@ get:
                   'DOMAIN_AGGREGATE_AND_PROOF': '0x06000000'
                   'INACTIVITY_PENALTY_QUOTIENT': '67108864'
                   'INACTIVITY_PENALTY_QUOTIENT_ALTAIR': '50331648'
-                  'BLOB_SCHEDULE': [{'EPOCH': '269568', 'MAX_BLOBS_PER_BLOCK': '6'},{'EPOCH': '364032', 'MAX_BLOBS_PER_BLOCK': '9'}]
+                  'BLOB_SCHEDULE': [{'EPOCH': '269568', 'MAX_BLOBS_PER_BLOCK': '6'}, {'EPOCH': '364032', 'MAX_BLOBS_PER_BLOCK': '9'}]
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError

--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -36,5 +36,6 @@ get:
                   'DOMAIN_AGGREGATE_AND_PROOF': '0x06000000'
                   'INACTIVITY_PENALTY_QUOTIENT': '67108864'
                   'INACTIVITY_PENALTY_QUOTIENT_ALTAIR': '50331648'
+                  'BLOB_SCHEDULE': [{'EPOCH': '269568', 'MAX_BLOBS_PER_BLOCK': '6'},{'EPOCH': '364032', 'MAX_BLOBS_PER_BLOCK': '9'}]
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError


### PR DESCRIPTION
To accommodate https://github.com/ethereum/consensus-specs/pull/4277 and clarify format we expect to be returned from `/eth/v1/config/spec` api.