### PR TITLE
Deprecate pre electra attestation submissions

### DIFF
--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -62,7 +62,6 @@ post:
 
     If one or more attestations fail validation, the node MUST return a 400 error with details of which attestations have failed, and why.
 
-    Prior to the Electra hard fork, this endpoint MUST be sent Attestation objects only.  At and after the Electra hard fork, this endpoint MUST be sent SingleAttestation objects only.
   parameters:
     - in: header
       schema:
@@ -78,13 +77,9 @@ post:
     content:
       application/json:
         schema:
-          oneOf:
-            - type: array
-              items:
-                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.SingleAttestation'
-            - type: array
-              items:
-                $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Phase0.Attestation'
+          - type: array
+          items:
+            $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Electra.SingleAttestation'
   responses:
     "200":
       description: Attestations are stored in pool and broadcast on the appropriate subnet


### PR DESCRIPTION
This PR aims to deprecate support for pre-electra `Attestations` in the `submitPoolAttestationsV2` endpoint. Since we are post Electra it seems that there is no reason to support the pre-Electra variant. It also allows client teams to simplify the implementation of this endpoint (e.g. Lighthouse can remove 100-ish lines of code with this deprecation). To be spec compliant clients must already be submitting `SingleAttestation`s to this endpoint, so unless there are non-spec compliant client implementations, this shouldn't cause any disruptions.