### PR TITLE
Update example to use valid json.

### DIFF
--- a/apis/config/spec.yaml
+++ b/apis/config/spec.yaml
@@ -37,6 +37,6 @@ get:
                   'DOMAIN_AGGREGATE_AND_PROOF': '0x06000000'
                   'INACTIVITY_PENALTY_QUOTIENT': '67108864'
                   'INACTIVITY_PENALTY_QUOTIENT_ALTAIR': '50331648'
-                  'BLOB_SCHEDULE': [{'EPOCH': '269568', 'MAX_BLOBS_PER_BLOCK': '6'}, {'EPOCH': '364032', 'MAX_BLOBS_PER_BLOCK': '9'}]
+                  'BLOB_SCHEDULE': [{"EPOCH": "269568", "MAX_BLOBS_PER_BLOCK": "6"}, {"EPOCH": "364032", "MAX_BLOBS_PER_BLOCK": "9"}]
     "500":
       $ref: ../../beacon-node-oapi.yaml#/components/responses/InternalError


### PR DESCRIPTION
The response for the `BLOB_SCHEDULE` should be a JSON array and the provided example does not conform to valid JSON. Updating to use double quotes as opposed to single quotes. 