### PR TITLE
Add data_column_sidecar event to eventstream API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ There are likely to be descriptions etc outside of the list below, but new query
 
 | Endpoint                                                                                                            | [Lighthouse](https://github.com/sigp/lighthouse) | [Lodestar](https://github.com/ChainSafe/lodestar) | [Nimbus](https://github.com/status-im/nimbus-eth2) | [Prysm](https://github.com/prysmaticlabs/prysm) | [Teku](https://github.com/ConsenSys/teku) |
 |---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|---------------------------------------------------|----------------------------------------------------|-------------------------------------------------|-------------------------------------------|
+| [#535](https://github.com/ethereum/beacon-APIs/pull/535) `data_column_sidecar EVENT` added | | | | | |
 
 The Following are no longer in the Standard API, removed since the latest version.
 

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -38,6 +38,7 @@ get:
             - light_client_optimistic_update
             - payload_attributes
             - blob_sidecar
+            - data_column_sidecar
   responses:
     "200":
       description: Opened SSE stream.
@@ -152,6 +153,11 @@ get:
               value: |
                 event: blob_sidecar
                 data: {"block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "index": "1", "slot": "1", "kzg_commitment": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505", "versioned_hash": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}
+            data_column_sidecar:
+              description: The node has received a DataColumnSidecar (from P2P or API) that passes all gossip validations on the data_column_sidecar_{subnet_id} topic
+              value: |
+                event: data_column_sidecar
+                data: {"block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "index": "1", "slot": "1", "kzg_commitments": ["0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"]}
     "400":
       description: "The topics supplied could not be parsed"
       content:
@@ -163,4 +169,3 @@ get:
             message: "Invalid topic: weather_forecast"
     "500":
       $ref: '../../beacon-node-oapi.yaml#/components/responses/InternalError'
-      


### PR DESCRIPTION
Extends the eventstream API to support data_column_sidecar events for PeerDAS (EIP-7594) data availability sampling. The event is emitted when the node receives a DataColumnSidecar that passes all gossip validations.