### PR TITLE
Add data column sidecars debug endpoint

### DIFF
--- a/apis/debug/data_column_sidecars.yaml
+++ b/apis/debug/data_column_sidecars.yaml
@@ -1,0 +1,73 @@
+get:
+  operationId: getDebugDataColumnSidecars
+  summary: Get data column sidecars
+  description: |
+    Retrieves data column sidecars for a given block id.
+    Depending on `Accept` header it can be returned either as json or as bytes serialized by SSZ.
+
+    If the `indices` parameter is specified, only the data column sidecars with the specified indices will be returned. There are no guarantees
+    for the returned data column sidecars in terms of ordering.
+  tags:
+    - Debug
+  parameters:
+    - name: block_id
+      in: path
+      required: true
+      $ref: '../../beacon-node-oapi.yaml#/components/parameters/BlockId'
+    - name: indices
+      in: query
+      description: Array of indices for data column sidecars to request for in the specified block. Returns all data column sidecars in the block if not specified.
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          $ref: '../../beacon-node-oapi.yaml#/components/schemas/Uint64'
+  responses:
+    "200":
+      description: "Successful response"
+      headers:
+        Eth-Consensus-Version:
+          $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Consensus-Version'
+      content:
+        application/json:
+          schema:
+            title: GetDebugDataColumnSidecarsResponse
+            type: object
+            required: [version, execution_optimistic, finalized, data]
+            properties:
+              version:
+                type: string
+                enum: [fulu]
+                example: "fulu"
+              execution_optimistic:
+                $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
+              finalized:
+                $ref: "../../beacon-node-oapi.yaml#/components/schemas/Finalized"
+              data:
+                $ref: "../../beacon-node-oapi.yaml#/components/schemas/Fulu.DataColumnSidecars"
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `DataColumnSidecars` bytes. Use Accept header to choose this response type"
+    "400":
+      description: "The block ID supplied could not be parsed"
+      content:
+        application/json:
+          schema:
+            $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 400
+            message: "Invalid block ID: current"
+    "404":
+      description: "Block not found"
+      content:
+        application/json:
+          schema:
+            $ref: "../../beacon-node-oapi.yaml#/components/schemas/ErrorMessage"
+          example:
+            code: 404
+            message: "Block not found"
+    "406":
+      $ref: "../../beacon-node-oapi.yaml#/components/responses/NotAcceptable"
+    "500":
+      $ref: "../../beacon-node-oapi.yaml#/components/responses/InternalError"

--- a/apis/debug/data_column_sidecars.yaml
+++ b/apis/debug/data_column_sidecars.yaml
@@ -16,7 +16,7 @@ get:
       $ref: '../../beacon-node-oapi.yaml#/components/parameters/BlockId'
     - name: indices
       in: query
-      description: Array of indices for data column sidecars to request for in the specified block. Returns all data column sidecars in the block if not specified.
+      description: Array of indices for data column sidecars to request for in the specified block. This endpoint will only return columns that the node is actually custodying. If not specified, returns all data column sidecars that this node is custodying in the block.
       required: false
       schema:
         type: array

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -118,6 +118,8 @@ paths:
     $ref: "./apis/beacon/blocks/attestations.v2.yaml"
   /eth/v1/beacon/blob_sidecars/{block_id}:
     $ref: "./apis/beacon/blob_sidecars/blob_sidecars.yaml"
+  /eth/v1/debug/beacon/data_column_sidecars/{block_id}:
+    $ref: "./apis/debug/data_column_sidecars.yaml"
   /eth/v1/beacon/rewards/sync_committee/{block_id}:
     $ref: "./apis/beacon/rewards/sync_committee.yaml"
   /eth/v1/beacon/deposit_snapshot:
@@ -442,6 +444,8 @@ components:
       $ref: "./types/fulu/block_contents.yaml#/Fulu/BlockContents"
     Fulu.SignedBlockContents:
       $ref: "./types/fulu/block_contents.yaml#/Fulu/SignedBlockContents"
+    Fulu.DataColumnSidecars:
+      $ref: "./types/fulu/data_column_sidecar.yaml#/Fulu/DataColumnSidecars"
     Node:
       $ref: './types/fork_choice.yaml#/Node'
     ExtraData:

--- a/types/fulu/data_column_sidecar.yaml
+++ b/types/fulu/data_column_sidecar.yaml
@@ -1,0 +1,44 @@
+Fulu:
+  DataColumnSidecars:
+    type: array
+    items:
+      $ref: '#/Fulu/DataColumnSidecar'
+    minItems: 0
+    maxItems: 128
+
+  KZGCommitmentsInclusionProof:
+    type: array
+    items:
+      $ref: "../primitive.yaml#/Bytes32"
+    minItems: 4
+    maxItems: 4
+
+  DataColumnSidecar:
+    type: object
+    description: "A data column sidecar as defined in the Fulu consensus spec."
+    required: [index, column, kzg_commitments, kzg_proofs, signed_block_header, kzg_commitments_inclusion_proof]
+    properties:
+      index:
+        $ref: "../primitive.yaml#/Uint64"
+      column:
+        type: array
+        items:
+          $ref: "../primitive.yaml#/Cell"
+        minItems: 0
+        maxItems: 4096
+      kzg_commitments:
+        type: array
+        items:
+          $ref: '../primitive.yaml#/KZGCommitment'
+        minItems: 0
+        maxItems: 4096
+      kzg_proofs:
+        type: array
+        items:
+          $ref: '../primitive.yaml#/KZGProof'
+        minItems: 0
+        maxItems: 4096
+      signed_block_header:
+        $ref: "../phase0/block.yaml#/Phase0/SignedBeaconBlockHeader"
+      kzg_commitments_inclusion_proof:
+        $ref: '#/Fulu/KZGCommitmentsInclusionProof'

--- a/types/fulu/data_column_sidecar.yaml
+++ b/types/fulu/data_column_sidecar.yaml
@@ -21,7 +21,7 @@ Fulu:
 
   DataColumnSidecar:
     type: object
-    description: "A data column sidecar as defined in the Fulu consensus spec."
+    description: "A [`DataColumnSidecar`](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#datacolumnsidecar) as defined in the Fulu consensus spec."
     required: [index, column, kzg_commitments, kzg_proofs, signed_block_header, kzg_commitments_inclusion_proof]
     properties:
       index:

--- a/types/fulu/data_column_sidecar.yaml
+++ b/types/fulu/data_column_sidecar.yaml
@@ -13,6 +13,12 @@ Fulu:
     minItems: 4
     maxItems: 4
 
+  DataColumn:
+    type: string
+    format: hex
+    pattern: "^0x[a-fA-F0-9]{4096}$"
+    description: "A data column is `FIELD_ELEMENTS_PER_CELL * size_of(BLSFieldElement) = 64 * 32 = 2048` bytes (`DATA`) representing a Cell as defined in Fulu"
+
   DataColumnSidecar:
     type: object
     description: "A data column sidecar as defined in the Fulu consensus spec."
@@ -23,7 +29,7 @@ Fulu:
       column:
         type: array
         items:
-          $ref: "../primitive.yaml#/Cell"
+          $ref: '#/Fulu/DataColumn'
         minItems: 0
         maxItems: 4096
       kzg_commitments:

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -142,3 +142,8 @@ KZGProof:
   pattern: "^0x[a-fA-F0-9]{96}$"
   description: "A G1 curve point. Used for verifying that the `KZGCommitment` for a given `Blob` is correct."
 
+Cell:
+  type: string
+  format: hex
+  pattern: "^0x[a-fA-F0-9]{4096}$"
+  description: "A 2048-byte hexadecimal string, prefixed with `0x`"

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -141,9 +141,3 @@ KZGProof:
   format: hex
   pattern: "^0x[a-fA-F0-9]{96}$"
   description: "A G1 curve point. Used for verifying that the `KZGCommitment` for a given `Blob` is correct."
-
-Cell:
-  type: string
-  format: hex
-  pattern: "^0x[a-fA-F0-9]{4096}$"
-  description: "A 2048-byte hexadecimal string, prefixed with `0x`"


### PR DESCRIPTION
Introduces support for data column sidecars as part of EIP-7594 (PeerDAS):
- Add /eth/v1/debug/beacon/data_column_sidecars/{block_id} endpoint
- Define DataColumnSidecar and related types for Fulu fork
- Add Cell primitive type for 2048-byte data columns