### PR TITLE
Add next fork digest to `MetaData`

### DIFF
--- a/types/p2p.yaml
+++ b/types/p2p.yaml
@@ -39,6 +39,9 @@ MetaData:
     custody_group_count:
       description: "Uint64 representing the node's custody group count. The metadata is present from the Fulu fork."
       $ref: "./primitive.yaml#/Uint64"
+    next_fork_digest:
+      description: "Byte4 representing the next fork digest. The metadata is present from the Fulu fork."
+      $ref: "./primitive.yaml#/Byte4"
 
 Peer:
   type: object

--- a/types/primitive.yaml
+++ b/types/primitive.yaml
@@ -60,6 +60,12 @@ Root:
   example: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
   pattern: "^0x[a-fA-F0-9]{64}$"
 
+Byte4:
+  type: string
+  format: hex
+  example: "0x00000000"
+  pattern: "^0x[a-fA-F0-9]{8}$"
+
 Bytes32:
   type: string
   format: hex


### PR DESCRIPTION
Similar to cgc, we want to add nfd to `MetaData`. 


Related to ethereum/consensus-specs#4354