### PR TITLE
Replace 415 response with 406 for apis that only have ssz response body

### DIFF
--- a/apis/beacon/states/pending_consolidations.yaml
+++ b/apis/beacon/states/pending_consolidations.yaml
@@ -42,7 +42,7 @@ get:
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "404":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/NotFound'
-    "415":
-      $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
+    "406":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/NotAcceptable'
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'

--- a/apis/beacon/states/pending_deposits.yaml
+++ b/apis/beacon/states/pending_deposits.yaml
@@ -42,8 +42,8 @@ get:
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "404":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/NotFound'
-    "415":
-      $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
+    "406":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/NotAcceptable'
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 

--- a/apis/beacon/states/pending_partial_withdrawals.yaml
+++ b/apis/beacon/states/pending_partial_withdrawals.yaml
@@ -42,8 +42,8 @@ get:
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InvalidRequest'
     "404":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/NotFound'
-    "415":
-      $ref: '../../../beacon-node-oapi.yaml#/components/responses/UnsupportedMediaType'
+    "406":
+      $ref: '../../../beacon-node-oapi.yaml#/components/responses/NotAcceptable'
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'
 


### PR DESCRIPTION
As suggested in https://github.com/ethereum/beacon-APIs/pull/539#discussion_r2139507320