### PR TITLE
attestation_data api clarification for Electra

### DIFF
--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -20,7 +20,9 @@ get:
         $ref: ../../beacon-node-oapi.yaml#/components/schemas/Uint64
     - name: committee_index
       in: query
-      description: "The committee index for which an attestation data should be created."
+      description: |
+        The committee index for which an attestation data should be created. For `slot`s in
+        Electra and later, this paramiter MAY always be set to 0.
       required: true
       schema:
         $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"

--- a/apis/validator/attestation_data.yaml
+++ b/apis/validator/attestation_data.yaml
@@ -22,7 +22,7 @@ get:
       in: query
       description: |
         The committee index for which an attestation data should be created. For `slot`s in
-        Electra and later, this paramiter MAY always be set to 0.
+        Electra and later, this parameter MAY always be set to 0.
       required: true
       schema:
         $ref: "../../beacon-node-oapi.yaml#/components/schemas/Uint64"


### PR DESCRIPTION
In electra, we are not required to call the endpoint for validators in different committees for the same slot.
The committeeIndex parameter is essentially redundant and could be always set to 0.