### PR TITLE
Query beacon committee selections only for the current epoch

### DIFF
--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -6,8 +6,9 @@ post:
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
     to correctly determine if any of its validators has been selected to perform an attestation aggregation duty in a slot. 
-    Validator clients running in a distributed validator cluster must query this endpoint at the start of an epoch for the current epoch for 
-    all validators that have attester duties in the current epoch. Consensus clients need not support this endpoint and may return a 501.
+    Validator clients running in a distributed validator cluster must query this endpoint at the start of an epoch either for all slots of 
+    the current epoch or for all slots of the current and all slots of the next epoch in two separate requests. In both cases it should be for 
+    all validators that have attester duties in the respective epoch. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:


### PR DESCRIPTION
Currently validator clients are incentivised to ask a distributed validator client middleware for selections for the current and future epochs. However, this creates some discrepancies with some clients asking only about the current one, while others ask for the next one.

Even though the next epoch request can be satisfied, as this request is triggered every epoch, there is no reason to be triggered for multiple epochs ahead. This can cause issues in scenarios where a distributed validator cluster has different validator clients. The DV cluster expects to get signed selections by threshold of nodes for the same slots in order to make successful aggregation. Sending requests with payloads of different slots prevents that, hence aggregations start to fail.

Edit: After some discussions, it seems like some client teams have this logic wired up to other API calls that are for the current and next epoch. Re-wiring it would be taking some time and seems unjustified for something that is working. That said, I have reworded to allow both scenarios, however, being more explicit. If a VC sends two requests for both current and next epoch it may not get its second request satisfied if no threshold is met from other peers. Its first request for current epoch should always be satisfied though.