### PR TITLE
Specify ideal_rewards coverage options for attestation rewards

### DIFF
--- a/apis/beacon/rewards/attestations.yaml
+++ b/apis/beacon/rewards/attestations.yaml
@@ -1,7 +1,23 @@
 post:
   operationId: getAttestationsRewards
   summary: Get attestations rewards
-  description: Retrieve attestation reward info for validators specified by array of public keys or validator index. If no array is provided, return reward info for every validator.
+  description: |
+    Retrieve attestation reward info for validators specified by array of public keys or validator index.
+    If no array is provided, return reward info for every validator.
+
+    The `total_rewards` field MUST contain one entry for every validator selected by the request.
+    The `ideal_rewards` field coverage is controlled by the `ideal_rewards` query parameter:
+    - `none`: `ideal_rewards` MUST be omitted from the response.
+    - `queried_validators`: `ideal_rewards` MUST contain one entry per distinct effective
+      balance present in `total_rewards`.
+    - `all`: `ideal_rewards` MUST contain one entry for every possible effective balance value for
+      the target epoch and fork.
+
+    If `ideal_rewards` is omitted:
+    - when the request body is not provided, it defaults to `all`.
+    - otherwise, it defaults to `queried_validators`.
+
+    When `ideal_rewards` is present, entries MUST be sorted by increasing `effective_balance`.
   tags:
     - Beacon
     - Rewards
@@ -12,6 +28,15 @@ post:
       description: "The epoch to get rewards info from"
       schema:
         $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Uint64"
+    - name: ideal_rewards
+      in: query
+      required: false
+      description: |
+        Controls `ideal_rewards` response coverage.
+        If omitted, defaults to `all` when no validator array is passed, otherwise defaults to
+        `queried_validators`.
+      schema:
+        $ref: "../../../beacon-node-oapi.yaml#/components/schemas/IdealRewardsMode"
   requestBody:
     description: "An array of either hex encoded public key (any bytes48 with 0x prefix) or validator index"
     required: false

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -231,6 +231,8 @@ components:
   schemas:
     BroadcastValidation:
       $ref: './types/api.yaml#/BroadcastValidation'
+    IdealRewardsMode:
+      $ref: './types/api.yaml#/IdealRewardsMode'
     ValidatorResponse:
       $ref: './types/api.yaml#/ValidatorResponse'
     ValidatorBalanceResponse:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -79,3 +79,9 @@ BroadcastValidation:
   description: Level of validation that must be applied to a block before it is broadcast.
   type: string
   enum: [gossip, consensus, consensus_and_equivocation]
+
+IdealRewardsMode:
+  description: |
+    Controls coverage of the `ideal_rewards` field in attestation rewards responses.
+  type: string
+  enum: [none, queried_validators, all]

--- a/types/rewards.yaml
+++ b/types/rewards.yaml
@@ -18,13 +18,18 @@ SyncCommitteeRewards:
 AttestationsRewards:
   type: object
   description: "Rewards info for attestations"
-  required: [ideal_rewards, total_rewards]
+  required: [total_rewards]
   properties:
     ideal_rewards:
+      description: |
+        Optional ideal rewards table keyed by effective balance.
+        Omitted when the request sets `ideal_rewards=none`.
       type: array
       items:
         $ref: ./rewards.yaml#/IdealAttestationRewards
     total_rewards:
+      description: |
+        One entry for every validator selected by the request for the target epoch.
       type: array
       items:
         $ref: ./rewards.yaml#/AttestationRewards


### PR DESCRIPTION
While implementing a rewards REST API and checking behavior across clients, I found that clients populate the `ideal_rewards` array differently. Prysm only returns ideal rewards for validators that were queried, while Lodestar returns all possible values for ideal rewards.

Given that I see applications for both behaviors, I would think that it's best to leave that choice to the calling user via a query parameter on the POST request. Setting ideal_rewards to `queried_validators` mimics Prysm, while setting it to `all` mimics Lodestar. If the caller isn't interested in that field, setting it to `none`, would suppress the array altogether.