### PR TITLE
Remove next epoch lookahead from PTC duties

### DIFF
--- a/apis/validator/duties/ptc.yaml
+++ b/apis/validator/duties/ptc.yaml
@@ -8,12 +8,10 @@ post:
     which should be performed by validators, for a particular epoch.
 
     Duties should only need to be checked once per epoch,
-    however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, resulting in a change of duties. For full safety,
+    however a chain reorganization could occur, resulting in a change of duties. For full safety,
     you should monitor head events and confirm the dependent root in this response matches:
 
       - event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`
-
-      - event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`
 
       - event.block otherwise
 
@@ -22,7 +20,7 @@ post:
     or the genesis block root in the case of underflow."
   parameters:
     - name: epoch
-      description: "Should only be allowed 1 epoch ahead"
+      description: "Epoch for which to obtain PTC duties. Must not be greater than the current epoch"
       in: path
       required: true
       schema:

--- a/validator-flow.md
+++ b/validator-flow.md
@@ -55,7 +55,7 @@ If reorg is detected, ask for new attester duties and proceed from 1..
 
 ### PTC Attesting
 
-On start of every epoch beginning with the Gloas fork, validator should [fetch PTC duties](#/Validator/getPtcDuties) for epoch + 1.
+On start of every epoch beginning with the Gloas fork, validator should [fetch PTC duties](#/Validator/getPtcDuties) for the current epoch.
 Result are array of objects with validator index and assigned slot for payload timeliness committee participation.
 
 PTC Attesting:


### PR DESCRIPTION
The PTC assignments are not stable for the next epoch so we should not be required to serve these duties via the api as we will need to re-compute them for the current epoch anyways. This PR effectively removes the requirement for clients to serve next epoch PTC duties.

Related https://github.com/ethereum/consensus-specs/pull/4992