### PR TITLE
Fix blob_gas_used / excess_blob_gas int width

### DIFF
--- a/types/deneb/execution_payload.yaml
+++ b/types/deneb/execution_payload.yaml
@@ -30,9 +30,9 @@ Deneb:
       base_fee_per_gas:
         $ref: '../primitive.yaml#/Uint256'
       blob_gas_used:
-        $ref: '../primitive.yaml#/Uint256'
+        $ref: '../primitive.yaml#/Uint64'
       excess_blob_gas:
-        $ref: '../primitive.yaml#/Uint256'  
+        $ref: '../primitive.yaml#/Uint64'
       block_hash:
         $ref: '../primitive.yaml#/Root'
 


### PR DESCRIPTION
The `blob_gas_used` and `excess_blob_gas` fields in the EL payload are `uint64` in the specs but here listed as `uint256`.

- https://github.com/ethereum/consensus-specs/blob/master/specs/deneb/beacon-chain.md#executionpayload