### PR TITLE
Fix justification_bits / sync_committee_bits types

### DIFF
--- a/types/altair/state.yaml
+++ b/types/altair/state.yaml
@@ -63,7 +63,7 @@ Altair:
       current_epoch_participation:
         $ref: './epoch_participation.yaml#/Altair/EpochParticipation'
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/altair/sync_aggregate.yaml
+++ b/types/altair/sync_aggregate.yaml
@@ -5,7 +5,7 @@ Altair:
     required: [sync_committee_bits, sync_committee_signature]
     properties:
       sync_committee_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Aggregation bits of sync"
       sync_committee_signature:
         $ref: '../primitive.yaml#/Signature'

--- a/types/bellatrix/state.yaml
+++ b/types/bellatrix/state.yaml
@@ -64,7 +64,7 @@ Bellatrix:
       current_epoch_participation:
         $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/capella/state.yaml
+++ b/types/capella/state.yaml
@@ -64,7 +64,7 @@ Capella:
       current_epoch_participation:
         $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/deneb/state.yaml
+++ b/types/deneb/state.yaml
@@ -64,7 +64,7 @@ Deneb:
       current_epoch_participation:
         $ref: '../altair/epoch_participation.yaml#/Altair/EpochParticipation'
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/electra/state.yaml
+++ b/types/electra/state.yaml
@@ -64,7 +64,7 @@ Electra:
       current_epoch_participation:
         $ref: "../altair/epoch_participation.yaml#/Altair/EpochParticipation"
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/fulu/state.yaml
+++ b/types/fulu/state.yaml
@@ -64,7 +64,7 @@ Fulu:
       current_epoch_participation:
         $ref: "../altair/epoch_participation.yaml#/Altair/EpochParticipation"
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"

--- a/types/phase0/state.yaml
+++ b/types/phase0/state.yaml
@@ -67,7 +67,7 @@ Phase0:
         items:
           $ref: './attestation.yaml#/Phase0/PendingAttestation'
       justification_bits:
-        $ref: "../primitive.yaml#/BitList"
+        $ref: "../primitive.yaml#/Bitvector"
         description: "Bit set for every recent justified epoch"
       previous_justified_checkpoint:
         $ref: "../misc.yaml#/Checkpoint"


### PR DESCRIPTION
BitList has the length mix-in when hashing, Bitvector doesn't (fix len). We got some of them wrong in the beacon-APIs. Only affects hashing.

- `justification_bits`: https://github.com/ethereum/consensus-specs/blob/master/specs/altair/beacon-chain.md#beaconstate
- `sync_committee_bits`: https://github.com/ethereum/consensus-specs/blob/master/specs/altair/beacon-chain.md#syncaggregate