### PR TITLE
Add parent_beacon_block_root to ExecutionPayloadEnvelope

### DIFF
--- a/types/gloas/execution_payload_envelope.yaml
+++ b/types/gloas/execution_payload_envelope.yaml
@@ -1,8 +1,8 @@
 Gloas:
   ExecutionPayloadEnvelope:
     type: object
-    description: "The [`ExecutionPayloadEnvelope`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/beacon-chain.md#executionpayloadenvelope) object from the CL Gloas spec."
-    required: [payload, execution_requests, builder_index, beacon_block_root, parent_beacon_block_root, slot, state_root]
+    description: "The [`ExecutionPayloadEnvelope`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.7/specs/gloas/beacon-chain.md#executionpayloadenvelope) object from the CL Gloas spec."
+    required: [payload, execution_requests, builder_index, beacon_block_root, parent_beacon_block_root]
     properties:
       payload:
         $ref: "../deneb/execution_payload.yaml#/Deneb/ExecutionPayload"
@@ -17,16 +17,10 @@ Gloas:
       parent_beacon_block_root:
         $ref: "../primitive.yaml#/Root"
         description: "Root of the parent beacon block"
-      slot:
-        $ref: "../primitive.yaml#/Uint64"
-        description: "Slot number for this execution payload"
-      state_root:
-        $ref: "../primitive.yaml#/Root"
-        description: "Beacon state root after executing this payload"
 
   SignedExecutionPayloadEnvelope:
     type: object
-    description: "The [`SignedExecutionPayloadEnvelope`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope) object from the CL Gloas spec."
+    description: "The [`SignedExecutionPayloadEnvelope`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.7/specs/gloas/beacon-chain.md#signedexecutionpayloadenvelope) object from the CL Gloas spec."
     required: [message, signature]
     properties:
       message:

--- a/types/gloas/execution_payload_envelope.yaml
+++ b/types/gloas/execution_payload_envelope.yaml
@@ -2,7 +2,7 @@ Gloas:
   ExecutionPayloadEnvelope:
     type: object
     description: "The [`ExecutionPayloadEnvelope`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/beacon-chain.md#executionpayloadenvelope) object from the CL Gloas spec."
-    required: [payload, execution_requests, builder_index, beacon_block_root, slot, state_root]
+    required: [payload, execution_requests, builder_index, beacon_block_root, parent_beacon_block_root, slot, state_root]
     properties:
       payload:
         $ref: "../deneb/execution_payload.yaml#/Deneb/ExecutionPayload"
@@ -14,6 +14,9 @@ Gloas:
       beacon_block_root:
         $ref: "../primitive.yaml#/Root"
         description: "Root of the beacon block for this payload"
+      parent_beacon_block_root:
+        $ref: "../primitive.yaml#/Root"
+        description: "Root of the parent beacon block"
       slot:
         $ref: "../primitive.yaml#/Uint64"
         description: "Slot number for this execution payload"


### PR DESCRIPTION
Spec adds new field `parent_beacon_block_root` to `ExecutionPayloadEnvelope` container, see https://github.com/ethereum/consensus-specs/pull/5152
Do we need it here too?