### PR TITLE
Add current_slot to fast_confirmation event

### DIFF
--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -191,10 +191,16 @@ get:
                 data: {"version":"gloas", "data":{"validator_index": "123", "data": {"beacon_block_root": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "slot": "10", "payload_present": true, "blob_data_available": true}, "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}}
             fast_confirmation:
               description: |
-                The node has executed the fast confirmation algorithm. This event should be emitted every time the algorithm is run,
-                regardless of whether the most recent confirmed block has changed since the previous run.
-                `block` and `slot` identify the most recent confirmed block, while `current_slot` is the
-                wall-clock slot at which the algorithm was executed.
+                The node has executed the fast confirmation algorithm.
+
+                The fields are:
+
+                - `block`: root of the most recent confirmed block.
+                - `slot`: slot of the most recent confirmed block.
+                - `current_slot`: wall-clock slot at which the algorithm was executed.
+
+                This event should be emitted every time the algorithm is run, regardless of whether
+                the most recent confirmed block has changed since the previous run.
               value: |
                 event: fast_confirmation
                 data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1", "current_slot": "2"}

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -190,17 +190,7 @@ get:
                 event: payload_attestation_message
                 data: {"version":"gloas", "data":{"validator_index": "123", "data": {"beacon_block_root": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "slot": "10", "payload_present": true, "blob_data_available": true}, "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}}
             fast_confirmation:
-              description: |
-                The node has executed the fast confirmation algorithm.
-
-                The fields are:
-
-                - `block`: root of the most recent confirmed block.
-                - `slot`: slot of the most recent confirmed block.
-                - `current_slot`: wall-clock slot at which the algorithm was executed.
-
-                This event should be emitted every time the algorithm is run, regardless of whether
-                the most recent confirmed block has changed since the previous run.
+              description: The node has executed the fast confirmation algorithm. This event should be emitted every time the algorithm is run, regardless of whether the most recent confirmed block has changed since the previous run. `block` is the root of the most recent confirmed block, `slot` is the slot of the most recent confirmed block, and `current_slot` is the wall-clock slot at which the algorithm was executed.
               value: |
                 event: fast_confirmation
                 data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1", "current_slot": "2"}

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -190,10 +190,14 @@ get:
                 event: payload_attestation_message
                 data: {"version":"gloas", "data":{"validator_index": "123", "data": {"beacon_block_root": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "slot": "10", "payload_present": true, "blob_data_available": true}, "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}}
             fast_confirmation:
-              description: The node has executed fast confirmation algorithm. The root and the slot of the most recent confirmed block are sent
+              description: |
+                The node has executed the fast confirmation algorithm. This event MUST be emitted every time the algorithm is run,
+                regardless of whether the most recent confirmed block has changed since the previous run.
+                `block` and `slot` identify the most recent confirmed block (root and its slot), while `current_slot` is the
+                wall-clock slot at which the algorithm was executed.
               value: |
                 event: fast_confirmation
-                data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1"}
+                data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1", "current_slot": "2"}
     "400":
       description: "The topics supplied could not be parsed"
       content:

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -191,9 +191,9 @@ get:
                 data: {"version":"gloas", "data":{"validator_index": "123", "data": {"beacon_block_root": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "slot": "10", "payload_present": true, "blob_data_available": true}, "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}}
             fast_confirmation:
               description: |
-                The node has executed the fast confirmation algorithm. This event MUST be emitted every time the algorithm is run,
+                The node has executed the fast confirmation algorithm. This event should be emitted every time the algorithm is run,
                 regardless of whether the most recent confirmed block has changed since the previous run.
-                `block` and `slot` identify the most recent confirmed block (root and its slot), while `current_slot` is the
+                `block` and `slot` identify the most recent confirmed block, while `current_slot` is the
                 wall-clock slot at which the algorithm was executed.
               value: |
                 event: fast_confirmation

--- a/apis/eventstream/index.yaml
+++ b/apis/eventstream/index.yaml
@@ -190,7 +190,7 @@ get:
                 event: payload_attestation_message
                 data: {"version":"gloas", "data":{"validator_index": "123", "data": {"beacon_block_root": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "slot": "10", "payload_present": true, "blob_data_available": true}, "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"}}
             fast_confirmation:
-              description: The node has executed the fast confirmation algorithm. This event should be emitted every time the algorithm is run, regardless of whether the most recent confirmed block has changed since the previous run. `block` is the root of the most recent confirmed block, `slot` is the slot of the most recent confirmed block, and `current_slot` is the wall-clock slot at which the algorithm was executed.
+              description: The node has executed the fast confirmation algorithm. This event should be emitted every time the algorithm is run, regardless of whether the most recent confirmed block has changed since the previous run. `block` is the root and `slot` is the slot of the most recent confirmed block, and `current_slot` is the wall-clock slot at which the algorithm was executed.
               value: |
                 event: fast_confirmation
                 data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1", "current_slot": "2"}


### PR DESCRIPTION
## Summary
- Add `current_slot` (wall-clock slot at execution time) to the `fast_confirmation` event payload, alongside the existing `block` and `slot` of the most recent confirmed block.
- Clarify that the event should be emitted every time the fast confirmation algorithm is run, regardless of whether the most recent confirmed block changed since the previous run.

## Motivation
Without `current_slot`, consumers cannot distinguish a fresh FCR run that re-confirmed the same block from a stale or missed emission. Making the emission cadence explicit in the spec removes ambiguity about whether implementations may suppress unchanged results.