### PR TITLE
Clarify pre-activation validator statuses and add deposit_inqueue for the post-Electra/Fulu deposit pipeline

### DIFF
--- a/apis/beacon/states/pending_deposits.yaml
+++ b/apis/beacon/states/pending_deposits.yaml
@@ -3,6 +3,8 @@ get:
   summary: "Get State Pending Deposits"
   description: |
     Returns pending deposits for state with given 'stateId'. Should return 400 if the state retrieved is prior to Electra.
+
+    A pubkey present here but absent from `state.validators` is in the deposit-pipeline state `deposit_inqueue`, it has no `ValidatorStatus` yet. This is the real churn-limited wait before a deposit becomes a validator.
   tags:
     - Beacon
   parameters:

--- a/types/api.yaml
+++ b/types/api.yaml
@@ -43,8 +43,8 @@ ValidatorIdentityResponse:
 ValidatorStatus:
   description: |
     Possible statuses:
-    - **pending_initialized** - When the first deposit is processed, but not enough funds are available (or not yet the end of the first epoch) to get validator into the activation queue.
-    - **pending_queued** - When validator is waiting to get activated, and have enough funds etc. while in the queue, validator activation epoch keeps changing until it gets to the front and make it through (finalization is a requirement here too).
+    - **pending_minBalance** - The validator exists in `state.validators` but its effective balance has not reached `MIN_ACTIVATION_BALANCE` (32 ETH), so it is not yet eligible for activation. Condition: `activation_eligibility_epoch == FAR_FUTURE_EPOCH`. (Formerly `pending_initialized`.)
+    - **pending_lookahead** - The validator is eligible (`activation_eligibility_epoch` is set and finalized) and its `activation_epoch` is assigned but in the future. Post-Electra (EIP-7251) this is a fixed `1 + MAX_SEED_LOOKAHEAD` delay, not a churn-limited queue: the `activation_epoch` does not change. Condition: `(activation_eligibility_epoch < FAR_FUTURE_EPOCH) and (activation_epoch > current_epoch)`. (Formerly `pending_queued`.)
     - **active_ongoing** - When validator must be attesting, and have not initiated any exit.
     - **active_exiting** - When validator is still active, but filed a voluntary request to exit.
     - **active_slashed** - When validator is still active, but have a slashed status and is scheduled to exit.
@@ -53,8 +53,10 @@ ValidatorStatus:
     - **withdrawal_possible** - After validator has exited, a while later is permitted to move funds, and is truly out of the system.
     - **withdrawal_done** - (not possible in phase0, except slashing full balance) - actually having moved funds away
 
+    Note: post-Electra (EIP-6110), a deposit that is in `state.pending_deposits` but not yet in `state.validators` is not represented by a `ValidatorStatus` (there is no validator object yet). This deposit-pipeline state — referred to as `deposit_inqueue` — is the real churn-limited wait and is observable via the `getPendingDeposits` endpoint, not via this enum.
+
     [Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)
-  enum: ["pending_initialized", "pending_queued", "active_ongoing", "active_exiting", "active_slashed", "exited_unslashed", "exited_slashed", "withdrawal_possible", "withdrawal_done"]
+  enum: ["pending_minBalance", "pending_lookahead", "active_ongoing", "active_exiting", "active_slashed", "exited_unslashed", "exited_slashed", "withdrawal_possible", "withdrawal_done"]
   example: "active_ongoing"
 
 


### PR DESCRIPTION
## Summary

The Beacon API `ValidatorStatus` enum (`types/api.yaml`) describes the two pre-activation states with Phase 0 semantics that no longer hold after Electra (EIP-6110 + EIP-7251) and Fulu.

This proposal:

1. Renames `pending_initialized` → `pending_minBalance` and clarifies its definition.
2. Renames `pending_queued` → `pending_lookahead` and corrects its (now inaccurate) description.
3. Adds a new deposit-level state, `deposit_inqueue`, for deposits that are in `state.pending_deposits` but not yet in `state.validators`.


## Motivation

The current `pending_queued` description in `types/api.yaml` reads:

> **pending_queued** — When validator is waiting to get activated, and have enough funds etc. while in the queue, validator **activation epoch keeps changing until it gets to the front and make it through** (finalization is a requirement here too).

This describes the Phase 0 activation mechanism, where `process_registry_updates` was the rate-limiting gate: validators competed for a churn-limited number of activation slots per epoch and their `activation_epoch` shifted as the queue drained.

That is no longer how activation works:

- **EIP-6110** moved deposit intake into `state.pending_deposits`, a per-epoch, churn-limited queue drained by `process_pending_deposits`.
- **EIP-7251** changed `process_registry_updates` to activate **every** eligible validator in a single pass (no churn, no per-epoch cap), and moved the churn gate upstream into `process_pending_deposits` (balance-based, ~256 ETH/epoch).

As a result, the two pre-activation states now mean:

- The state currently called `pending_initialized` is really "the validator exists but its effective balance has not reached `MIN_ACTIVATION_BALANCE` (32 ETH), so it is not yet eligible." Its name conveys none of this.
- The state currently called `pending_queued` is **not a queue**. Once `activation_eligibility_epoch` is finalized, `activation_epoch` is set to a fixed `current_epoch + 1 + MAX_SEED_LOOKAHEAD` and **does not change** regardless of how many other validators are activating. It is a fixed-duration lookahead, not a queue position.

The real churn-limited queue — the one that can hold a deposit for days or weeks — is `state.pending_deposits`, and it has no representation in the validator status enum at all, because the deposit is not yet a validator. This is the state operators actually ask about ("where is my deposit / how long until activation"), and the API cannot currently express it.

## Proposed changes

### 1. New: `deposit_inqueue` (deposit-level, not a `ValidatorStatus`)

A deposit sits in `state.pending_deposits` and the pubkey is not yet in `state.validators`.

This is where the real churn-limited wait happens.

- **Condition:** pubkey present in `state.pending_deposits`, absent from `state.validators`.
- **Observability:** there is no validator object to attach a status to, so this is **not** returned by `/eth/v1/beacon/states/{state_id}/validators`. It is observable via the existing `getPendingDeposits` endpoint (`/eth/v1/beacon/states/{state_id}/pending_deposits`).

We recommend documenting `deposit_inqueue` as a deposit-pipeline state rather than adding it to the `ValidatorStatus` enum (which is, by construction, derived from registered-validator fields).

### 2. `pending_initialized` → `pending_minBalance`

Validator exists in `state.validators` but its effective balance has not reached `MIN_ACTIVATION_BALANCE` (32 ETH), so it is not yet eligible for activation.

- **Condition:** `validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH`
- Lasts while effective balance < 32 ETH (or, briefly, until the first epoch boundary after a full deposit stamps eligibility).

### 3. `pending_queued` → `pending_lookahead`

Validator is eligible (`activation_eligibility_epoch` set and finalized) and `activation_epoch` is assigned but in the future. This is a fixed `1 + MAX_SEED_LOOKAHEAD` delay, not a queue.

- **Condition:** `(validator.activation_eligibility_epoch < FAR_FUTURE_EPOCH) and (validator.activation_epoch > current_epoch)`



## Status reference (pre-activation)

| Current name | Proposed name | Condition | Real meaning post-Electra |
|---|---|---|---|
| (none) | `deposit_inqueue` | in `state.pending_deposits`, not in `state.validators` | The actual churn-limited queue (≤ ~8 validators/epoch at mainnet scale) |
| `pending_initialized` | `pending_minBalance` | `activation_eligibility_epoch == FAR_FUTURE_EPOCH` | Validator created, effective balance < 32 ETH |
| `pending_queued` | `pending_lookahead` | `activation_eligibility_epoch < FAR_FUTURE_EPOCH` and `activation_epoch > current_epoch` | Eligible; fixed `1 + MAX_SEED_LOOKAHEAD` delay (not a queue) |

All `active_*`, `exited_*`, and `withdrawal_*` statuses are unchanged.


## Backward compatibility

`deposit_inqueue` is additive: documenting a deposit-pipeline state and pointing consumers at the existing `getPendingDeposits` endpoint breaks nothing.

The renames (`pending_initialized` → `pending_minBalance`, `pending_queued` → `pending_lookahead`) **are breaking** for any consumer that matches on the string values (clients, explorers, dashboards, the `?status=` query filter on `/validators`). Options for discussion:

- **A — Clarify only, do not rename.** Keep `pending_initialized` / `pending_queued`, fix their descriptions, and add `deposit_inqueue`. Zero breakage; lowest friction to merge.
- **B — Rename with deprecation window.** Introduce the new names, keep the old ones as accepted aliases (request and response) for a defined number of releases, then remove. Highest clarity, needs ecosystem coordination.

This PR is written for option B; if reviewers prefer to avoid the breaking change, it degrades cleanly to option A (the description fixes and `deposit_inqueue` stand on their own).

## References
- `types/api.yaml` — current `ValidatorStatus` enum and descriptions
- EIP-6110 — Supply validator deposits on chain
- EIP-7251 — Increase the MAX_EFFECTIVE_BALANCE
- consensus-specs `electra/beacon-chain.md` — `process_pending_deposits`, `process_registry_updates`
- `apis/beacon/states/pending_deposits.yaml` — existing `getPendingDeposits` endpoint

---

*Proposal by [MigaLabs](https://migalabs.io), coordinated by @Leobago.*
