### PR TITLE
Add SSZ response support for validator_balances endpoints

### DIFF
--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -67,6 +67,8 @@ get:
           example:
             code: 404
             message: "State not found"
+    "406":
+      $ref: "../../../beacon-node-oapi.yaml#/components/responses/NotAcceptable"
     "414":
       description: "Too many validator IDs"
       content:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -90,6 +90,8 @@ post:
     match any known validator, no balance will be returned but this will not cause an error. There are no guarantees for the
     returned data in terms of ordering; the index is returned for each balance, and can be used to confirm for which inputs a
     response has been returned.
+
+    Depending on `Accept` header data can be returned either as JSON or as bytes serialized by SSZ.
   tags:
     - Beacon
   parameters:
@@ -128,6 +130,9 @@ post:
                 type: array
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorBalanceResponse'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `List[Container{index: uint64, balance: uint64}, VALIDATOR_REGISTRY_LIMIT]` bytes. Use Accept header to choose this response type"
     "400":
       description: "Invalid state ID or malformed request"
       content:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -8,6 +8,8 @@ get:
     match any known validator, no balance will be returned but this will not cause an error. There are no guarantees for the
     returned data in terms of ordering; the index is returned for each balance, and can be used to confirm for which inputs a
     response has been returned.
+
+    Depending on `Accept` header data can be returned either as JSON or as bytes serialized by SSZ.
   tags:
     - Beacon
   parameters:
@@ -44,6 +46,9 @@ get:
                 type: array
                 items:
                   $ref: '../../../beacon-node-oapi.yaml#/components/schemas/ValidatorBalanceResponse'
+        application/octet-stream:
+          schema:
+            description: "SSZ serialized `List[Container{index: uint64, balance: uint64}, VALIDATOR_REGISTRY_LIMIT]` bytes. Use Accept header to choose this response type"
     "400":
       description: "Invalid state or validator ID"
       content:

--- a/apis/beacon/states/validator_balances.yaml
+++ b/apis/beacon/states/validator_balances.yaml
@@ -151,5 +151,7 @@ post:
           example:
             code: 404
             message: "State not found"
+    "406":
+      $ref: "../../../beacon-node-oapi.yaml#/components/responses/NotAcceptable"
     "500":
       $ref: '../../../beacon-node-oapi.yaml#/components/responses/InternalError'


### PR DESCRIPTION
## What

Adds an `application/octet-stream` (SSZ) response to `GET` and `POST
/eth/v1/beacon/states/{state_id}/validator_balances`, selectable via the
`Accept` header, plus a `406 Not Acceptable` matching the other SSZ-enabled
state endpoints (`validator_identities`, `pending_partial_withdrawals`).

The SSZ payload is `List[ValidatorBalanceResponse, VALIDATOR_REGISTRY_LIMIT]`,
each entry being the container `{ index: uint64, balance: uint64 }`. It is
purely additive: no JSON changes, no new parameters, JSON consumers are
untouched.

## Context

Split out of #601 per the discussion there (cc @nflaig, @etan-status,
@lodekeeper). `validator_balances` has no `status` and no enum, so the SSZ
enum questions raised for the `validators` endpoint do not apply here. The
`validators` side stays at status quo for now; this is the uncontroversial
half.

## Already shipping

This documents behavior clients already serve. Lodestar has returned SSZ on
this endpoint since ChainSafe/lodestar#6749 (v1.20.0, around two years), with
the same `{index, balance}` shape (confirmed by @lodekeeper in #601). Adding
SSZ to an existing endpoint is backward compatible via `Accept` header content
negotiation.

The concrete consumer is analytics/indexing: MigaLabs' goteth snapshots
balances per processed epoch and backfills large historical ranges, where the
JSON encode/parse cost on both ends is the bottleneck (gzip cuts wire size but
not that CPU). SSZ reduces both.

## Validation

`redocly lint ./beacon-node-oapi.yaml` is valid and `swagger-cli bundle`
succeeds, matching the CI.

## Tests

The spec is validated by lint + bundle rather than a test suite, so there is
no test harness to extend here. If you would like anything beyond that (an
example payload, or a client conformance check), say so and I will add it.

Related: #601, #333.
