### PR TITLE
Change producePayloadAttestationData slot path parameter to query parameter

### DIFF
--- a/apis/validator/payload_attestation_data.yaml
+++ b/apis/validator/payload_attestation_data.yaml
@@ -13,7 +13,7 @@ get:
     A 503 error must be returned if the beacon node is currently syncing.
   parameters:
     - name: slot
-      in: path
+      in: query
       required: true
       description: "The slot for which payload attestation data should be created."
       schema:

--- a/beacon-node-oapi.yaml
+++ b/beacon-node-oapi.yaml
@@ -200,7 +200,7 @@ paths:
     $ref: "./apis/validator/block.v4.yaml"
   /eth/v1/validator/attestation_data:
     $ref: "./apis/validator/attestation_data.yaml"
-  /eth/v1/validator/payload_attestation_data/{slot}:
+  /eth/v1/validator/payload_attestation_data:
     $ref: "./apis/validator/payload_attestation_data.yaml"
   /eth/v2/validator/aggregate_attestation:
     $ref: "./apis/validator/aggregate_attestation.v2.yaml"


### PR DESCRIPTION
Makes the endpoint consistent with the `produceAttestationData` endpoint.

Related discussion on Discord and in #612 .