### PR TITLE
Add a plugin to make SSZ request body description visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,30 @@
     <script src="./dist/swagger-ui-bundle.js"> </script>
     <script src="./dist/swagger-ui-standalone-preset.js"> </script>
     <script>
+    // A plugin to render the schema description for binary media types in the RequestBody component.
+    // rather than showing "Example values are not available for <type> media types."
+    const RequestBodySchemaDescription = () => ({
+      wrapComponents: {
+        RequestBody: (Original, system) => (props) => {
+          const React = system.React
+          const contentType = props.contentType || ""
+          const isBinaryMediaType = ["application/octet-stream", "image/", "audio/", "video/"]
+            .some((mediaType) => contentType.startsWith(mediaType))
+          const description = isBinaryMediaType && props.requestBody
+            ? props.requestBody.getIn(["content", contentType, "schema", "description"])
+            : null
+          if (!description) {
+            return React.createElement(Original, props)
+          }
+          const Markdown = system.getComponent("Markdown", true)
+          return React.createElement("div", null,
+            React.createElement("div", {className: "request-body-schema-description"},
+              React.createElement(Markdown, {source: description})),
+            React.createElement(Original, props))
+        }
+      }
+    })
+
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
@@ -70,7 +94,8 @@
           SwaggerUIStandalonePreset
         ],
         plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl
+          SwaggerUIBundle.plugins.DownloadUrl,
+          RequestBodySchemaDescription
         ],
         layout: "StandaloneLayout"
    })

--- a/index.html
+++ b/index.html
@@ -44,16 +44,15 @@
     <script src="./dist/swagger-ui-bundle.js"> </script>
     <script src="./dist/swagger-ui-standalone-preset.js"> </script>
     <script>
-    // A plugin to render the schema description for binary media types in the RequestBody component.
+    // A plugin to render the schema description for application/octet-stream in the RequestBody component,
     // rather than showing "Example values are not available for <type> media types."
     const RequestBodySchemaDescription = () => ({
       wrapComponents: {
         RequestBody: (Original, system) => (props) => {
           const React = system.React
           const contentType = props.contentType || ""
-          const isBinaryMediaType = ["application/octet-stream", "image/", "audio/", "video/"]
-            .some((mediaType) => contentType.startsWith(mediaType))
-          const description = isBinaryMediaType && props.requestBody
+          const isOctetStreamType = contentType.startsWith("application/octet-stream")
+          const description = isOctetStreamType && props.requestBody
             ? props.requestBody.getIn(["content", contentType, "schema", "description"])
             : null
           if (!description) {


### PR DESCRIPTION
This is sort of hacky way to render a description for SSZ request body via Swagger UI. This covers all 9 octet-stream request bodies at once:
- `POST /eth/v2/beacon/blinded_blocks`
- `POST /eth/v2/beacon/blocks`
- `POST /eth/v1/beacon/execution_payload_bids`
- `POST /eth/v1/beacon/execution_payload_envelopes`
- `POST /eth/v2/beacon/pool/attestations`
- `POST /eth/v1/beacon/pool/payload_attestations`
- `POST /eth/v2/validator/aggregate_and_proofs`
- `POST /eth/v1/validator/register_validator`
- `POST /eth/v1/validator/proposer_preferences`

Example:

<img width="1216" height="137" alt="image" src="https://github.com/user-attachments/assets/1c76d097-ee08-4153-a352-99585ad43a5c" />

Today it just shows like

```
Example values are not available for application/octet-stream media types.
```