### PR TITLE
Specify SSZ framing for `GET /eth/v1/debug/beacon/data_column_sidecars/{block_id}`

### DIFF
--- a/apis/debug/data_column_sidecars.yaml
+++ b/apis/debug/data_column_sidecars.yaml
@@ -50,7 +50,7 @@ get:
                   - $ref: "../../beacon-node-oapi.yaml#/components/schemas/Fulu.DataColumnSidecars"
         application/octet-stream:
           schema:
-            description: "SSZ serialized `DataColumnSidecars` bytes. Use Accept header to choose this response type"
+            description: "SSZ serialized `List[DataColumnSidecar, NUMBER_OF_COLUMNS]` bytes. Use Accept header to choose this response type"
     "400":
       description: "The block ID supplied could not be parsed"
       content:


### PR DESCRIPTION
`GET /eth/v1/debug/beacon/data_column_sidecars/{block_id}` declares its SSZ response as:

> SSZ serialized `DataColumnSidecars` bytes.

`DataColumnSidecars` is not an SSZ type, so it might be confusing for encoding the response. Here's a research conducted by Claude:

| Client | Framing | Source |
|---|---|---|
| Lighthouse | `List` | `beacon_node/http_api/src/lib.rs` → `data_columns.as_ssz_bytes()` on `DataColumnSidecarList = Vec<Arc<DataColumnSidecar<E>>>` (offset-framed for variable-size `T`) |
| Nimbus | `List` | `beacon_chain/rpc/rest_debug_api.nim` → `handleDataSidecarRequest[..., List[fulu.DataColumnSidecar, NUMBER_OF_COLUMNS]]`, `sszResponse` on the `List` |
| Lodestar | `List` | `packages/api/src/beacon/routes/debug.ts` → `sszTypesFor(fork).DataColumnSidecars`, i.e. `new ListCompositeType(DataColumnSidecar, NUMBER_OF_COLUMNS)` |
| Grandine | `List` | `http_api/src/standard.rs::debug_beacon_data_column_sidecars` → `DynamicList<Arc<DataColumnSidecar<P>>>`, whose `SszWrite` is `shared::write_list` |
| Teku | concatenation | `.../v1/debug/GetDataColumnSidecars.java` → `data.forEach(s -> s.sszSerialize(out))` |
| Prysm | concatenation | `beacon-chain/rpc/eth/debug/handlers.go::buildDataColumnSidecarsSSZResponse` → loops `MarshalSSZ` and appends |

I can tell Prysm is just concatenating it, so about to fix this.

This PR clarifies and specifies that we are gonna use SSZ List for the response, so the clients can prepend offset bytes before marshalling the items.