### PR TITLE
Use progressive list for payload attestation pool response

### DIFF
--- a/apis/beacon/pool/payload_attestations.yaml
+++ b/apis/beacon/pool/payload_attestations.yaml
@@ -33,7 +33,7 @@ get:
                   $ref: "../../../beacon-node-oapi.yaml#/components/schemas/Gloas.PayloadAttestation"
         application/octet-stream:
           schema:
-            description: "SSZ serialized `List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]` bytes. Use Accept header to choose this response type"
+            description: "SSZ serialized `ProgressiveList[PayloadAttestation]` bytes. Use Accept header to choose this response type"
     "400":
       description: "The slot could not be parsed"
       content:


### PR DESCRIPTION
`MAX_PAYLOAD_ATTESTATIONS` limits attestations included in a block for one parent, but the pool response may contain attestations for multiple block roots or slots and exceed 4 entries

Describe the SSZ response as `ProgressiveList[PayloadAttestation]`, matching the unbounded JSON response and the Gloas `PayloadAttestations` type

h/t to Caleb for finding this