### PR TITLE
Clarify `Eth-Builder-Url` response-header description

### DIFF
--- a/apis/validator/block.v4.yaml
+++ b/apis/validator/block.v4.yaml
@@ -119,9 +119,9 @@ post:
         Eth-Builder-Url:
           description: |
             The `url` of a winning builder when the bid was retrieved via the builder-API.
-            The validator client MUST echo this value in the `Eth-Builder-Url` request header when publishing
-            the signed block, so the beacon node can forward the block to the same builder via
-            `submitSignedBeaconBlock`. Absent for a self-built block or a bid won over p2p.
+            The validator client MUST echo this value in the `Eth-Builder-Url` request header when
+            publishing the signed block, so the beacon node can forward the block to the same builder
+            via `submitSignedBeaconBlock`. Absent for a self-built block or a bid won over p2p.
           required: false
           schema:
             type: string

--- a/apis/validator/block.v4.yaml
+++ b/apis/validator/block.v4.yaml
@@ -118,7 +118,7 @@ post:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Included'
         Eth-Builder-Url:
           description: |
-            The `url` of a winning builder when the bid was retrieved via the builder-API (pull-path).
+            The `url` of a winning builder when the bid was retrieved via the builder-API.
             The validator client MUST echo this value in the `Eth-Builder-Url` request header when publishing
             the signed block, so the beacon node can forward the block to the same builder via
             `submitSignedBeaconBlock`. Absent for a self-built block or a bid won over p2p.

--- a/apis/validator/block.v4.yaml
+++ b/apis/validator/block.v4.yaml
@@ -118,11 +118,10 @@ post:
           $ref: '../../beacon-node-oapi.yaml#/components/headers/Eth-Execution-Payload-Included'
         Eth-Builder-Url:
           description: |
-            When the winning bid came through the builder-API channel, the `url` of that builder.
-            The validator echoes this value in the `Eth-Builder-Url` request header when publishing
-            the signed block, so the beacon node can forward the block to the same builder via the
-            builder-API `submitSignedBeaconBlock`. Absent when the block was self-built or the
-            winning bid came from the p2p network.
+            The `url` of a winning builder when the bid was retrieved via the builder-API (pull-path).
+            The validator client MUST echo this value in the `Eth-Builder-Url` request header when publishing
+            the signed block, so the beacon node can forward the block to the same builder via
+            `submitSignedBeaconBlock`. Absent for a self-built block or a bid won over p2p.
           required: false
           schema:
             type: string


### PR DESCRIPTION
Clarification of the `Eth-Builder-Url` description. Tightens "echoes" to "MUST echo", in accordance with `blocks.v2.yaml`.