### PR TITLE
Allow "gloas" version on all applicable endpoints

### DIFF
--- a/apis/beacon/blocks/attestations.v2.yaml
+++ b/apis/beacon/blocks/attestations.v2.yaml
@@ -25,7 +25,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu]
+                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
                 example: "fulu"
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/beacon/blocks/attestations.v2.yaml
+++ b/apis/beacon/blocks/attestations.v2.yaml
@@ -26,7 +26,7 @@ get:
               version:
                 type: string
                 enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
-                example: "fulu"
+                example: "gloas"
               execution_optimistic:
                 $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
               finalized:

--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -31,7 +31,7 @@ get:
               version:
                 type: string
                 enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
-                example: "fulu"
+                example: "gloas"
               data:
                 anyOf:
                   - type: array

--- a/apis/beacon/pool/attestations.v2.yaml
+++ b/apis/beacon/pool/attestations.v2.yaml
@@ -30,7 +30,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu]
+                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
                 example: "fulu"
               data:
                 anyOf:

--- a/apis/beacon/pool/attester_slashings.v2.yaml
+++ b/apis/beacon/pool/attester_slashings.v2.yaml
@@ -20,7 +20,7 @@ get:
               version:
                 type: string
                 enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
-                example: "fulu"
+                example: "gloas"
               data:
                 anyOf:
                   - type: array

--- a/apis/beacon/pool/attester_slashings.v2.yaml
+++ b/apis/beacon/pool/attester_slashings.v2.yaml
@@ -19,7 +19,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu]
+                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
                 example: "fulu"
               data:
                 anyOf:

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -26,7 +26,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu]
+                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
                 example: "fulu"
               execution_optimistic:
                 $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"

--- a/apis/debug/state.v2.yaml
+++ b/apis/debug/state.v2.yaml
@@ -27,7 +27,7 @@ get:
               version:
                 type: string
                 enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
-                example: "fulu"
+                example: "gloas"
               execution_optimistic:
                 $ref: "../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
               finalized:

--- a/apis/validator/aggregate_attestation.v2.yaml
+++ b/apis/validator/aggregate_attestation.v2.yaml
@@ -46,7 +46,7 @@ get:
               version:
                 type: string
                 enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
-                example: "fulu"
+                example: "gloas"
               data:
                 anyOf:
                   - $ref: '../../beacon-node-oapi.yaml#/components/schemas/Electra.Attestation'

--- a/apis/validator/aggregate_attestation.v2.yaml
+++ b/apis/validator/aggregate_attestation.v2.yaml
@@ -45,7 +45,7 @@ get:
             properties:
               version:
                 type: string
-                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu]
+                enum: [phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas]
                 example: "fulu"
               data:
                 anyOf:


### PR DESCRIPTION
Vero's Beacon API compliance tests revealed the `"gloas"` (fork) `version` value is not allowed on some Beacon API endpoints where it should be allowed -> this PR fixes that.